### PR TITLE
major: remove tailscale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,6 @@ COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} Pipfile Pipfile
 COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} Pipfile.lock Pipfile.lock
 COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} app/ /code/app
 
-COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /app/tailscaled
-COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /app/tailscale
-
-
-
-
 RUN devbox run -- echo "Installed Packages."
 RUN devbox run pipenv install
 # https://stackoverflow.com/questions/34370962/no-module-named-cffi-backend

--- a/devbox.json
+++ b/devbox.json
@@ -16,9 +16,6 @@
           "eval $(ssh-agent -s)",
           "chmod 600 /code/id_ed25519",
           "ssh-add /code/id_ed25519",
-          "/app/tailscaled --tun=userspace-networking --socks5-server=localhost:1055 &",
-          "/app/tailscale up --auth-key=${TAILSCALE_AUTHKEY} --hostname=${HOSTNAME}",
-          "export ALL_PROXY=socks5://localhost:1055/",
           "devbox run pipenv run fastapi run"
       ],
       "dev": [


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed Tailscale binaries from the Dockerfile, simplifying the image build process.
- Eliminated Tailscale-related commands from the `k8s` script in `devbox.json`, streamlining the development setup.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Remove Tailscale binaries from Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Removed Tailscale binaries from the Docker image.<br> <li> Simplified the Dockerfile by eliminating unnecessary COPY commands.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/8/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>devbox.json</strong><dd><code>Remove Tailscale setup from devbox.json scripts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

devbox.json

<li>Removed Tailscale-related commands from the <code>k8s</code> script.<br> <li> Simplified the <code>k8s</code> script by eliminating Tailscale setup.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/8/files#diff-3d4c81b2bef90b8980e7c7c4900d75007f13acf07d9e62aa509f2d53f9fa4ef9">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information