### PR TITLE
fix: missing comma on virt.py

### DIFF
--- a/app/util/virt.py
+++ b/app/util/virt.py
@@ -27,7 +27,7 @@ def create_virtual_machine(
         "--disk", f"path={disk_path},format={disk_format}",
         "--os-variant", os_variant,
         "--network", f"bridge={network_bridge},model={network_model}",
-        "--cloud-init", f"user-data={user_data}"
+        "--cloud-init", f"user-data={user_data}",
         "--noautoconsole",
     ]
     


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a syntax error by adding a missing comma in the `create_virtual_machine` function in `virt.py`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>virt.py</strong><dd><code>Fix missing comma in virtual machine creation command</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/util/virt.py

<li>Added a missing comma in the command list for creating a virtual <br>machine.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/10/files#diff-e29e0c7994e30a9adca076b4ea403932fc49d586ddc415beb512bc9affdb98fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information