### PR TITLE
fix: change encoder to b64

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -93,7 +93,7 @@ async def create_vm(vm: Vm, api_key: str = Depends(get_api_key)):
         virt.create_virtual_machine(
             connect=CONNECT_URI,
             name=f"{vm.vm_name}",
-            metadata_description=encoder.encode_string(json.dumps(vm.tags)),
+            metadata_description=b64.encode_string(json.dumps(vm.tags)),
             ram=10240,
             vcpus=2,
             disk_path=f"/var/lib/libvirt/images/{vm.vm_name}.qcow2",

--- a/app/util/virsh.py
+++ b/app/util/virsh.py
@@ -98,6 +98,6 @@ def format_vm_list(connect, output):
             'id': dom_id,
             'name': name,
             'state': state,
-            'description': json.loads(encoder.decode_string(describe_vm(connect, name)))
+            'description': json.loads(b64.decode_string(describe_vm(connect, name)))
         })
     return domains


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed encoding and decoding of VM metadata and descriptions by switching from `encoder` to `b64`.
- Ensured consistent use of base64 encoding for virtual machine operations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Update encoder to base64 for metadata description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/main.py

<li>Changed encoder from <code>encoder</code> to <code>b64</code> for encoding metadata description.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/12/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>virsh.py</strong><dd><code>Update decoder to base64 for VM descriptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/util/virsh.py

<li>Changed encoder from <code>encoder</code> to <code>b64</code> for decoding VM descriptions.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/12/files#diff-2c3fa182e351cbd653f97c66bd1ca7c9b850d3c97472fe3cdb080dd0a735e300">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information