### PR TITLE
fix: ssh key agent issue on startup

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -13,7 +13,7 @@
       ],
       "k8s": [
           "printf '%s\n' $SSH_PRIVATE_KEY_ED25519_BASE64_ENCODED | base64 --decode > /code/id_ed25519",
-          "mkdir -p ~/.ssh && echo -e 'Host *\n    StrictHostKeyChecking no' >> ~/.ssh/config && chmod 600 ~/.ssh/config",
+          "mkdir -p ~/.ssh && echo 'Host *\n    StrictHostKeyChecking no' >> ~/.ssh/config && chmod 600 ~/.ssh/config",
           "eval $(ssh-agent -s)",
           "chmod 600 /code/id_ed25519",
           "ssh-add /code/id_ed25519",

--- a/devbox.json
+++ b/devbox.json
@@ -13,6 +13,7 @@
       ],
       "k8s": [
           "printf '%s\n' $SSH_PRIVATE_KEY_ED25519_BASE64_ENCODED | base64 --decode > /code/id_ed25519",
+          "mkdir -p ~/.ssh && echo -e 'Host *\n    StrictHostKeyChecking no' >> ~/.ssh/config && chmod 600 ~/.ssh/config",
           "eval $(ssh-agent -s)",
           "chmod 600 /code/id_ed25519",
           "ssh-add /code/id_ed25519",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added SSH configuration to disable strict host key checking for all remote connections
- Automatically creates ~/.ssh directory and config file with appropriate permissions (600)
- Enhances automation by removing interactive host verification prompts
- Configuration applies globally to all SSH connections within the devbox environment



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devbox.json</strong><dd><code>Disable SSH strict host key checking in devbox configuration</code></dd></summary>
<hr>

devbox.json

<li>Added SSH configuration to disable strict host key checking for all <br>hosts<br> <li> Configuration is added to the k8s script section<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/16/files#diff-3d4c81b2bef90b8980e7c7c4900d75007f13acf07d9e62aa509f2d53f9fa4ef9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information