### PR TITLE
feat: add server libvirt install script for debian servers

### DIFF
--- a/install-server.sh
+++ b/install-server.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+
+echo -e "\n\nEverything is now getting setup. This process will take a few minutes...\n\n"
+
+sudo apt update && sudo apt install gpg jq -y && sudo apt clean
+
+#remove unattended upgrades
+sudo apt-get remove --purge unattended-upgrades || true
+
+#Install tailscale
+curl -fsSL https://tailscale.com/install.sh | sh
+
+#Install nix package manager
+sh <(curl -L https://nixos.org/nix/install) --daemon --yes
+
+# Load the Nix environment
+. /etc/profile.d/nix.sh
+
+# Install packages from a pinned version of Nixpkgs
+nix-env -iA \
+  -f https://github.com/NixOS/nixpkgs/archive/53f3c92b4d1f5f297258954c5026e39c45afd180.tar.gz \
+  libvirt qemu bridge-utils virt-manager dnsmasq
+
+# Find the Nix-installed dnsmasq binary
+DNSMASQ_BIN=$(which dnsmasq)
+LIBVIRTD_BIN=$(which libvirtd)
+
+
+if [[ -z "$DNSMASQ_BIN" || -z "$LIBVIRTD_BIN" ]]; then
+    echo "Error: One or both binaries (dnsmasq, libvirtd) not found after installation!"
+    exit 1
+fi
+
+# Create a systemd service for dnsmasq
+echo "Creating systemd service for dnsmasq..."
+sudo bash -c "cat > /etc/systemd/system/dnsmasq-nix.service" <<EOF
+[Unit]
+Description=DNS caching server (via Nix)
+After=network.target
+
+[Service]
+ExecStart=$DNSMASQ_BIN --no-daemon
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Create a systemd service for libvirtd
+echo "Creating systemd service for libvirtd..."
+sudo bash -c "cat > /etc/systemd/system/libvirtd-nix.service" <<EOF
+[Unit]
+Description=Virtualization daemon (via Nix)
+After=network.target
+
+[Service]
+ExecStart=$LIBVIRTD_BIN
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Reload systemd, enable, and start the service
+echo "Enabling and starting dnsmasq service..."
+sudo systemctl daemon-reload
+sudo systemctl enable dnsmasq-nix libvirtd-nix
+sudo systemctl start dnsmasq-nix libvirtd-nix
+
+# Verify the service is running
+echo "Checking dnsmasq service status..."
+sudo systemctl status dnsmasq-nix --no-pager
+
+echo "Checking libvirtd service status..."
+sudo systemctl status libvirtd-nix --no-page

--- a/install-server.sh
+++ b/install-server.sh
@@ -35,7 +35,7 @@ Description=DNS caching server (via Nix)
 After=network.target
 
 [Service]
-ExecStart=$DNSMASQ_BIN --no-daemon
+ExecStart=$DNSMASQ_BIN --no-daemon --no-resolv --server=1.1.1.1 --server=8.8.8.8
 Restart=always
 
 [Install]
@@ -70,6 +70,3 @@ if ! systemctl is-active --quiet dnsmasq-nix || ! systemctl is-active --quiet li
     echo "Error: One or more services failed to start properly"
     exit 1
 fi
-
-# Append DNS server to dnsmasq.conf
-echo "server=1.1.1.1" | sudo tee -a /etc/dnsmasq.conf


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
Adds a new installation script for Debian servers that:
- Sets up Tailscale for secure networking
- Installs Nix package manager and uses it to manage virtualization packages
- Configures libvirt, QEMU, and related tools from pinned Nixpkgs version
- Creates and enables systemd services for dnsmasq and libvirtd
- Includes error handling and service status verification
- Removes unattended upgrades to prevent automatic updates



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install-server.sh</strong><dd><code>Server setup script for virtualization environment with Nix</code></dd></summary>
<hr>

install-server.sh

<li>Installs essential packages (gpg, jq) and removes unattended upgrades<br> <li> Sets up Tailscale and Nix package manager<br> <li> Installs and configures libvirt, qemu, and related virtualization <br>tools via Nix<br> <li> Creates and enables systemd services for dnsmasq and libvirtd<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/17/files#diff-ef4449716ec6861eacb1970ca1b80769459952ec0426e204dd727ceb1a06db0a">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information