### PR TITLE
fix: add ssh ports to install script

### DIFF
--- a/install-server.sh
+++ b/install-server.sh
@@ -70,3 +70,10 @@ if ! systemctl is-active --quiet dnsmasq-nix || ! systemctl is-active --quiet li
     echo "Error: One or more services failed to start properly"
     exit 1
 fi
+
+# Replace '#Port' with 'Port 22' and 'Port 2222'
+sudo sed -i 's/^#Port .*/Port 22\nPort 2222/' /etc/ssh/sshd_config
+
+# Restart the ssh service to apply changes
+echo "Restarting ssh service."
+sudo systemctl restart ssh


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added configuration to enable both default (22) and alternative (2222) SSH ports in sshd_config file
- Added automatic SSH service restart to apply the new port configuration
- Enhances server accessibility by providing multiple SSH connection options



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install-server.sh</strong><dd><code>Configure multiple SSH ports in installation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

install-server.sh

<li>Added configuration to enable SSH ports 22 and 2222 in sshd_config<br> <li> Added SSH service restart after port configuration<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/20/files#diff-ef4449716ec6861eacb1970ca1b80769459952ec0426e204dd727ceb1a06db0a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information