### PR TITLE
fix: change installscript from nix pkgs to debian apt pkgs

### DIFF
--- a/install-server.sh
+++ b/install-server.sh
@@ -6,70 +6,22 @@ echo -e "\n\nEverything is now getting setup. This process will take a few minut
 #Install tailscale
 curl -fsSL https://tailscale.com/install.sh | sh
 
-#Install nix package manager
-sh <(curl -L https://nixos.org/nix/install) --daemon --yes
+#Install libvirt and related packages
+sudo apt install -y qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager dnsmasq qemu-utils xmlstarlet jq
 
-# Load the Nix environment
-. /etc/profile.d/nix.sh
+#If you have trouble with dnsmasq
+sudo systemctl disable --now systemd-resolved || true
+sudo apt remove systemd-resolved || true
+sudo rm /etc/resolv.conf || true
+{ echo "nameserver 1.1.1.1"; echo "nameserver 8.8.8.8"; } | sudo tee /etc/resolv.conf
 
-# Install packages from a pinned version of Nixpkgs
-nix-env -iA \
-  -f https://github.com/NixOS/nixpkgs/archive/53f3c92b4d1f5f297258954c5026e39c45afd180.tar.gz \
-  libvirt qemu bridge-utils virt-manager dnsmasq
+#Enable and start libvirt
+sudo systemctl enable libvirtd
+sudo systemctl start libvirtd
 
-# Find the Nix-installed dnsmasq binary
-DNSMASQ_BIN=$(which dnsmasq)
-LIBVIRTD_BIN=$(which libvirtd)
-
-
-if [[ -z "$DNSMASQ_BIN" || -z "$LIBVIRTD_BIN" ]]; then
-    echo "Error: One or both binaries (dnsmasq, libvirtd) not found after installation!"
-    exit 1
-fi
-
-# Create a systemd service for dnsmasq
-echo "Creating systemd service for dnsmasq..."
-sudo bash -c "cat > /etc/systemd/system/dnsmasq-nix.service" <<EOF
-[Unit]
-Description=DNS caching server (via Nix)
-After=network.target
-
-[Service]
-ExecStart=$DNSMASQ_BIN --no-daemon --no-resolv --server=1.1.1.1 --server=8.8.8.8
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-# Create a systemd service for libvirtd
-echo "Creating systemd service for libvirtd..."
-sudo bash -c "cat > /etc/systemd/system/libvirtd-nix.service" <<EOF
-[Unit]
-Description=Virtualization daemon (via Nix)
-After=network.target
-
-[Service]
-ExecStart=$LIBVIRTD_BIN
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-# Reload systemd, enable, and start the service
-echo "Enabling and starting dnsmasq service..."
-sudo systemctl daemon-reload
-sudo systemctl enable dnsmasq-nix libvirtd-nix
-sudo systemctl start dnsmasq-nix libvirtd-nix
-
-sudo systemctl start dnsmasq-nix libvirtd-nix
- 
-# Verify services are actually running
-if ! systemctl is-active --quiet dnsmasq-nix || ! systemctl is-active --quiet libvirtd-nix; then
-    echo "Error: One or more services failed to start properly"
-    exit 1
-fi
+#Enable the default network
+sudo virsh net-start default
+sudo virsh net-autostart default
 
 # Replace '#Port' with 'Port 22' and 'Port 2222'
 sudo sed -i 's/^#Port .*/Port 22\nPort 2222/' /etc/ssh/sshd_config


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Simplified the installation process by using native Debian/Ubuntu package management (apt) instead of Nix
- Installed virtualization packages directly: qemu-kvm, libvirt, bridge-utils, virt-manager, and related tools
- Improved DNS configuration by replacing systemd-resolved with direct nameserver configuration
- Added automatic setup of libvirt default network
- Maintained existing SSH and Tailscale configuration



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install-server.sh</strong><dd><code>Switch from Nix to APT package management for virtualization setup</code></dd></summary>
<hr>

install-server.sh

<li>Removed Nix package manager installation and related systemd services<br> <li> Added direct installation of libvirt and related packages using apt<br> <li> Added configuration for DNS resolution using Cloudflare and Google DNS<br> <li> Added setup for libvirt default network<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/22/files#diff-ef4449716ec6861eacb1970ca1b80769459952ec0426e204dd727ceb1a06db0a">+16/-64</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information