### PR TITLE
fix: downgrade libvirt to match provisioner node

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -3,7 +3,7 @@
   "packages": [
     "python-full@3.11.10",
     "pipenv@2024.2.0",
-    "libvirt@10.9.0",
+    "libvirt@9.0.0",
     "virt-manager@4.1.0"
   ],
   "shell": {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Downgraded `libvirt` package from version 10.9.0 to 9.0.0 to ensure compatibility with the provisioner node
- This change helps prevent version mismatch issues between development and provisioning environments



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devbox.json</strong><dd><code>Downgrade libvirt package version for compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

devbox.json

<li>Downgraded <code>libvirt</code> package version from 10.9.0 to 9.0.0 to match <br>provisioner node version<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/23/files#diff-3d4c81b2bef90b8980e7c7c4900d75007f13acf07d9e62aa509f2d53f9fa4ef9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information