### PR TITLE
feat: make /v1/list endpoint async to speed it up

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -142,7 +142,7 @@ async def list_vms(api_key: str = Depends(get_api_key)):
         except Exception as e:
             logger.error(f"Error listing VMs from {cfg.connect_uri}: {e}")
             logger.error(traceback.format_exc())
-            return []
+            raise
 
     tasks = [list_vm_for_region(cfg) for cfg in REGIONS]
     results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/app/main.py
+++ b/app/main.py
@@ -142,7 +142,6 @@ async def list_vms(api_key: str = Depends(get_api_key)):
         except Exception as e:
             logger.error(f"Error listing VMs from {cfg.connect_uri}: {e}")
             logger.error(traceback.format_exc())
-            raise
 
     tasks = [list_vm_for_region(cfg) for cfg in REGIONS]
     results = await asyncio.gather(*tasks, return_exceptions=True)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactored `/v1/list` endpoint to use asynchronous processing.

- Introduced `asyncio.gather` for parallel VM listing across regions.

- Added error handling for individual region tasks during VM listing.

- Improved performance by leveraging `asyncio.to_thread` for blocking calls.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Refactored `/v1/list` endpoint for async and parallel processing</code></dd></summary>
<hr>

app/main.py

<li>Refactored <code>/v1/list</code> endpoint to use asynchronous processing.<br> <li> Added <code>asyncio.gather</code> for parallel VM listing tasks.<br> <li> Introduced <code>asyncio.to_thread</code> for handling blocking calls.<br> <li> Enhanced error handling for individual region tasks.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/30/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+22/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information