### PR TITLE
feat: add github image api to provisioner

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -190,16 +190,6 @@ async def health():
     """
     return {"status": "healthy"}
 
-
-def update_image_cache_on_provisioner_nodes():
-    logger.info("Running image cache")
-    release_watcher = github.ReleaseWatcher()
-    if release_watcher.check_for_new_release():
-        for config in REGIONS:
-            ssh.execute_ssh_command(config.host, config.user, config.port, "bash <(curl https://raw.githubusercontent.com/GlueOps/development-only-utilities/refs/tags/v0.26.0/tools/developer-setup/cache-images-for-libvirt.sh)")
-            logger.info(f"Finished caching image on {config.host}")
-
-@app.get("/update-image-cache")
-async def update_image_cache(background_tasks: BackgroundTasks):
-    background_tasks.add_task(update_image_cache_on_provisioner_nodes)
-    return {"message": "Caching latest image"}
+@app.get("/v1/get-images")
+async def get_vm_images(image_env = 'prod'):
+    return { "images": github.get_codespace_releases(image_env) }

--- a/app/util/github.py
+++ b/app/util/github.py
@@ -1,48 +1,35 @@
 import requests
-import os, glueops.setup_logging, traceback, json
+import os, glueops.setup_logging, traceback
 
 # Configure logging
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 logger = glueops.setup_logging.configure(level=LOG_LEVEL)
 
-class ReleaseWatcher:
-    def __init__(self, url="https://api.github.com/repos/glueops/codespaces/releases?per_page=1"):
-        """
-        Initialize the ReleaseWatcher with a default URL to check for new releases.
-        Stores internal state for the last tag and last assets.
-        """
-        self.url = url
-        self.last_tag = None
-        self.last_assets = set()
+def get_codespace_releases(environment):
+    """
+    Checks GitHub API for releases.
+    Fetches the latest 5 stable releases and the latest 5 releases (including prereleases).
+    """
+    try:
+        # response = requests.get('https://api.github.com/repos/glueops/codespaces/releases?per_page=10')
+        response = requests.get('https://api.github.com/repos/nicharcha82/test/releases?per_page=10')
+        response.raise_for_status()
+        releases = response.json()
 
-    def check_for_new_release(self):
-        """
-        Checks the endpoint for the latest release. If the tag or asset URLs
-        differ from the stored state it returns True
-        """
-        try:
-            response = requests.get(self.url)
-            response.raise_for_status()
-            releases = response.json()
-            
-            if not releases:
-                logger.info("No releases returned from the API.")
-                return
-            
-            latest_release = releases[0]
-            new_tag = latest_release.get("tag_name", None)
-            assets = latest_release.get("assets", [])
-            new_assets = set(asset.get("browser_download_url") for asset in assets)
+        if not releases:
+            logger.error("No releases returned from the API.")
+            raise ValueError("No releases found")
+        
+        if environment == 'nonprod':
+            # Get the latest 5 releases (including prereleases)
+            latest_any = [release["tag_name"] for release in releases[:5]]
+            return latest_any
 
-            # Consolidated check for new tag or new assets:
-            if new_tag != self.last_tag or new_assets != self.last_assets:
-                logger.info(f"new tag: {new_tag} or new asset_urls: {new_assets}")
-                
-                # Update internal state
-                self.last_tag = new_tag
-                self.last_assets = new_assets
-                return True
+        if environment == 'prod':
+            # Get the latest 5 stable releases (filter out prereleases)
+            stable_releases = [release["tag_name"] for release in releases if not release.get("prerelease")][:5]
+            return stable_releases
 
-        except requests.exceptions.RequestException as err:
-            logger.error(f"Request failed: {traceback.format_exc()}")
-            raise
+    except requests.exceptions.RequestException as err:
+        logger.error(f"Request failed: {traceback.format_exc()}")
+        raise

--- a/app/util/github.py
+++ b/app/util/github.py
@@ -11,8 +11,7 @@ def get_codespace_releases(environment):
     Fetches the latest 5 stable releases and the latest 5 releases (including prereleases).
     """
     try:
-        # response = requests.get('https://api.github.com/repos/glueops/codespaces/releases?per_page=10')
-        response = requests.get('https://api.github.com/repos/nicharcha82/test/releases?per_page=10')
+        response = requests.get('https://api.github.com/repos/glueops/codespaces/releases?per_page=10')
         response.raise_for_status()
         releases = response.json()
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a new API endpoint `/v1/get-images` to fetch VM images.

- Implemented `get_codespace_releases` function to retrieve GitHub releases.

- Removed outdated `update_image_cache` endpoint and related logic.

- Simplified and optimized GitHub release handling logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Introduced `/v1/get-images` endpoint and removed old logic.</code></dd></summary>
<hr>

app/main.py

<li>Added a new <code>/v1/get-images</code> endpoint to fetch VM images.<br> <li> Removed the <code>update_image_cache</code> endpoint and its background task logic.<br> <li> Simplified the code by removing unused functions.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/57/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+3/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>github.py</strong><dd><code>Added `get_codespace_releases` and removed `ReleaseWatcher`.</code></dd></summary>
<hr>

app/util/github.py

<li>Added <code>get_codespace_releases</code> function to fetch GitHub releases.<br> <li> Removed <code>ReleaseWatcher</code> class and its associated logic.<br> <li> Simplified release fetching with environment-based filtering.<br> <li> Improved error handling for API requests.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/57/files#diff-047285d60c06a65a1fdcee094d06e40beb20c35e049b1a4e5d85c27137d85ece">+25/-39</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>