### PR TITLE
fix: change image api to use env var

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 logger = glueops.setup_logging.configure(level=LOG_LEVEL)
 BAREMETAL_SERVER_CONFIGS = os.getenv('BAREMETAL_SERVER_CONFIGS', '[]')
 REGIONS = regions.get_region_configs(BAREMETAL_SERVER_CONFIGS)
+PROVISIONER_ENVIRONMENT = os.getenv('PROVISIONER_ENVIRONMENT')
 #ENV variables
 
 API_TOKEN = os.getenv('API_TOKEN')
@@ -191,5 +192,5 @@ async def health():
     return {"status": "healthy"}
 
 @app.get("/v1/get-images")
-async def get_vm_images(image_env = 'prod'):
-    return { "images": github.get_codespace_releases(image_env) }
+async def get_vm_images():
+    return { "images": github.get_codespace_releases(PROVISIONER_ENVIRONMENT) }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated `/v1/get-images` endpoint to use `PROVISIONER_ENVIRONMENT`.

- Introduced `PROVISIONER_ENVIRONMENT` environment variable for configuration.

- Improved code consistency by removing hardcoded `image_env` parameter.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Refactor `/v1/get-images` to use environment variable</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/main.py

<li>Added <code>PROVISIONER_ENVIRONMENT</code> environment variable for configuration.<br> <li> Modified <code>/v1/get-images</code> endpoint to use <code>PROVISIONER_ENVIRONMENT</code>.<br> <li> Removed hardcoded <code>image_env</code> parameter from the endpoint.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/58/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>