### PR TITLE
fix: required env vars don't crash the app on startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,6 @@ from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
 from typing import Optional, Dict, List
 from pydantic import BaseModel, Field
-from contextlib import asynccontextmanager
 from util import ssh, virt, virsh, formatter, b64, regions, github
 import os, glueops.setup_logging, traceback, base64, yaml, tempfile, json, asyncio
 from schemas.schemas import ExistingVm, Vm, VmMeta, Message
@@ -15,37 +14,12 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 logger = glueops.setup_logging.configure(level=LOG_LEVEL)
 BAREMETAL_SERVER_CONFIGS = os.getenv('BAREMETAL_SERVER_CONFIGS', '[]')
 REGIONS = regions.get_region_configs(BAREMETAL_SERVER_CONFIGS)
-PROVISIONER_ENVIRONMENT = os.getenv('PROVISIONER_ENVIRONMENT')
-#ENV variables
-
-API_TOKEN = os.getenv('API_TOKEN')
+PROVISIONER_ENVIRONMENT = os.environ['PROVISIONER_ENVIRONMENT']
+API_TOKEN = os.environ['API_TOKEN']
 
 api_key_header = APIKeyHeader(name="Authorization")
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    """Startup function to test env variables
-    crashes if env variables are not set
-
-    Args:
-        app (FastAPI)
-
-    Raises:
-        Exception: env variables not set
-    """
-    
-    required_env_vars = [ "API_TOKEN"]
-
-    for var in required_env_vars:
-        if var not in os.environ:
-            raise Exception(f"Environment variable {var} is not set.")
-    yield
-
-#define the FastAPI app with lifespan
-#for startup function
-
 app = FastAPI()
-# app = FastAPI(lifespan=lifespan)
 
 @app.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):

--- a/app/main.py
+++ b/app/main.py
@@ -14,8 +14,12 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 logger = glueops.setup_logging.configure(level=LOG_LEVEL)
 BAREMETAL_SERVER_CONFIGS = os.getenv('BAREMETAL_SERVER_CONFIGS', '[]')
 REGIONS = regions.get_region_configs(BAREMETAL_SERVER_CONFIGS)
-PROVISIONER_ENVIRONMENT = os.environ['PROVISIONER_ENVIRONMENT']
-API_TOKEN = os.environ['API_TOKEN']
+try:
+    PROVISIONER_ENVIRONMENT = os.environ['PROVISIONER_ENVIRONMENT']
+    API_TOKEN = os.environ['API_TOKEN']
+except KeyError as e:
+    logger.critical(f"Required environment variable {e} is not set")
+    raise SystemExit(1)
 
 api_key_header = APIKeyHeader(name="Authorization")
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed app crash on startup due to missing environment variables.

- Replaced `os.getenv` with `os.environ` for required variables.

- Removed unused `lifespan` function and related code.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Fixed environment variable handling and removed unused code</code></dd></summary>
<hr>

app/main.py

<li>Replaced <code>os.getenv</code> with <code>os.environ</code> for strict environment variable <br>checks.<br> <li> Removed <code>lifespan</code> function that validated environment variables.<br> <li> Deleted redundant comments and unused imports.<br> <li> Simplified app initialization by removing the lifespan dependency.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/59/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+2/-28</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>