### PR TITLE
feat: improve response time for list_vms

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -121,7 +121,7 @@ async def list_vms(api_key: str = Depends(get_api_key)):
             logger.info(f"Requesting VM list from: {cfg.connect_uri}")
             # Use `asyncio.to_thread` to call a blocking function; 
             # if virsh.list_vms is already async, just call it directly.
-            return await asyncio.to_thread(virsh.list_vms, cfg.connect_uri, cfg.region_name)
+            return await asyncio.to_thread(virsh.list_vms, cfg)
         except Exception as e:
             logger.error(f"Error listing VMs from {cfg.connect_uri}: {e}")
             logger.error(traceback.format_exc())

--- a/app/util/virsh.py
+++ b/app/util/virsh.py
@@ -1,4 +1,4 @@
-from . import b64
+from . import b64, ssh
 import subprocess, os, glueops.setup_logging, traceback, re, json
 # Configure logging
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
@@ -42,36 +42,43 @@ def start_vm(connect, vm_name):
         logger.error(traceback.format_exc())
         raise
 
-def describe_vm(connect, vm_name):
-    """describe a virtual machine."""
-    cmd = ["virsh", "--connect", connect, "desc", vm_name]
+def list_vms(region_config):
+    """List virtual machines."""
+    bash_get_all_vms_script = f"""
+        printf "%-5s %-30s %-12s %-40s\\n" "Id" "Name" "State" "Description"
+        echo "-------------------------------------------------------------------------------------------------------------"
+        
+        # Use 'virsh list --all' to get all VM names, IDs, and states in one call
+        all_info=$(virsh list --all)
+    
+        # Process each line of the `virsh list --all` output
+        echo "$all_info" | awk 'NR>2 {{print $1,$2,$3}}' | while read -r id name state; do
+            # Skip machines that are not named
+            [ -z "$name" ] && continue
+    
+            # For each VM, get its description as a single additional call
+            desc=$(virsh desc "$name" 2>/dev/null | head -n 1)
+            desc=${{desc:-<No description>}}
+    
+            # Print the formatted output in a single printf call
+            printf "%-5s %-30s %-12s %-40s\\n" "$id" "$name" "$state" "$desc"
+        done
+        """
     try:
-        result = subprocess.run(cmd, check=True, text=True, capture_output=True)
-        logger.info(f"VM: {vm_name} Description: {result.stdout.strip()}")
-        return result.stdout.strip()
-    except subprocess.CalledProcessError as e:
-        logger.error(f"Error starting VM '{vm_name}': {e.stderr}")
-        logger.error(traceback.format_exc())
-        raise
-
-def list_vms(connect, region_name):
-    """Start a virtual machine."""
-    cmd = ["virsh", "--connect", connect, "list", "--all"]
-    try:
-        result = subprocess.run(cmd, check=True, text=True, capture_output=True)
-        logger.info(f"{result.stdout}")
-        vms = format_vm_list(connect, region_name, result.stdout)
+        result = ssh.execute_ssh_command(region_config.host, region_config.user, region_config.port, bash_get_all_vms_script)
+        logger.info(f"{result}")
+        vms = format_vm_list(region_config.region_name, result)
         logger.info(vms)
         return vms
-    except subprocess.CalledProcessError as e:
+    except Exception as e:
         logger.error(f"Error listing vms")
         logger.error(traceback.format_exc())
         raise
 
 
-def format_vm_list(connect, region_name, output):
+def format_vm_list(region_name, output):
     """
-    Parses the output of 'virsh list --all' and returns a list of domains with a description.
+    Parses the outputs of 'virsh list --all' and 'virsh desc' and returns a list of domains with a description.
     Each domain is represented as a dictionary with keys: id, name, state, description.
     """
     lines = output.strip().split('\n')
@@ -89,16 +96,16 @@ def format_vm_list(connect, region_name, output):
         
         # Split the line based on two or more spaces
         parts = re.split(r'\s{2,}', line.strip())
-        if len(parts) != 3:
+        if len(parts) != 4:
             logger.error(f"Unexpected line format: '{line}'")
             raise Exception(f'Unexpected vm line item {line}')
 
-        dom_id, name, state = parts
+        dom_id, name, state, description = parts
         domains.append({
             'dom_id': dom_id,
             'name': name,
             'region_name': region_name,
             'state': state,
-            'tags': json.loads(b64.decode_string(describe_vm(connect, name)))
+            'tags': json.loads(b64.decode_string(description))
         })
     return domains


### PR DESCRIPTION
### **User description**
Reverts GlueOps/provisioner#63


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored `list_vms` to use SSH for remote execution.

- Improved VM listing output with formatted descriptions.

- Fixed incorrect handling of VM descriptions in `format_vm_list`.

- Updated `list_vm_for_region` to pass a single configuration object.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Refactored <code>list_vm_for_region</code> for streamlined configuration handling</code></dd></summary>
<hr>

app/main.py

<li>Updated <code>list_vm_for_region</code> to pass a single configuration object.<br> <li> Simplified the function call to <code>virsh.list_vms</code>.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/64/files#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249dd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>virsh.py</strong><dd><code>Refactored VM listing with SSH and improved formatting</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/util/virsh.py

<li>Refactored <code>list_vms</code> to use SSH for remote execution.<br> <li> Replaced subprocess calls with a formatted bash script.<br> <li> Enhanced <code>format_vm_list</code> to handle VM descriptions correctly.<br> <li> Removed redundant <code>describe_vm</code> function.


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/64/files#diff-2c3fa182e351cbd653f97c66bd1ca7c9b850d3c97472fe3cdb080dd0a735e300">+32/-25</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>