### PR TITLE
fix: remove page count to default to 30 images

### DIFF
--- a/app/util/github.py
+++ b/app/util/github.py
@@ -8,7 +8,7 @@ logger = glueops.setup_logging.configure(level=LOG_LEVEL)
 def get_codespace_releases(environment):
     """
     Checks GitHub API for 30 releases.
-    Filters the retrieved released for the latest 5 stable releases and the latest 5 releases (including prereleases).
+    Filters the retrieved releases for the latest 5 stable releases and the latest 5 releases (including prereleases).
     """
     try:
         response = requests.get('https://api.github.com/repos/glueops/codespaces/releases')

--- a/app/util/github.py
+++ b/app/util/github.py
@@ -7,8 +7,8 @@ logger = glueops.setup_logging.configure(level=LOG_LEVEL)
 
 def get_codespace_releases(environment):
     """
-    Checks GitHub API for releases.
-    Fetches the latest 5 stable releases and the latest 5 releases (including prereleases).
+    Checks GitHub API for 30 releases.
+    Filters the retrieved released for the latest 5 stable releases and the latest 5 releases (including prereleases).
     """
     try:
         response = requests.get('https://api.github.com/repos/glueops/codespaces/releases')

--- a/app/util/github.py
+++ b/app/util/github.py
@@ -11,7 +11,7 @@ def get_codespace_releases(environment):
     Fetches the latest 5 stable releases and the latest 5 releases (including prereleases).
     """
     try:
-        response = requests.get('https://api.github.com/repos/glueops/codespaces/releases?per_page=10')
+        response = requests.get('https://api.github.com/repos/glueops/codespaces/releases')
         response.raise_for_status()
         releases = response.json()
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed explicit `per_page` parameter to default to 30 releases from GitHub API

- Updated function and inline comments for clarity on release filtering


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.py</strong><dd><code>Default to 30 releases and clarify code comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/util/github.py

<li>Removed <code>per_page=10</code> from GitHub releases API call to use default (30)<br> <li> Updated docstring to clarify retrieval and filtering of releases<br> <li> Improved inline comment for better understanding<br> <li> Minor spelling and clarity improvements


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/67/files#diff-047285d60c06a65a1fdcee094d06e40beb20c35e049b1a4e5d85c27137d85ece">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>