### PR TITLE
feat: Increase release retrieval limit to 60

### DIFF
--- a/app/util/github.py
+++ b/app/util/github.py
@@ -20,13 +20,13 @@ def get_codespace_releases(environment):
             raise ValueError("No releases found")
         
         if environment == 'nonprod':
-            # Get the latest 5 releases (including prereleases)
-            latest_any = [release["tag_name"] for release in releases[:5]]
+            # Get the latest 60 releases (including prereleases)
+            latest_any = [release["tag_name"] for release in releases[:60]]
             return latest_any
 
         if environment == 'prod':
-            # Get the latest 5 stable releases (filter out prereleases)
-            stable_releases = [release["tag_name"] for release in releases if not release.get("prerelease")][:5]
+            # Get the latest 60 stable releases (filter out prereleases)
+            stable_releases = [release["tag_name"] for release in releases if not release.get("prerelease")][:60]
             return stable_releases
 
     except requests.exceptions.RequestException as err:

--- a/app/util/github.py
+++ b/app/util/github.py
@@ -7,11 +7,11 @@ logger = glueops.setup_logging.configure(level=LOG_LEVEL)
 
 def get_codespace_releases(environment):
     """
-    Checks GitHub API for 30 releases.
-    Filters the retrieved releases for the latest 5 stable releases and the latest 5 releases (including prereleases).
+    Checks GitHub API for 60 releases.
+    Filters the retrieved releases for the latest 5 stable releases and the latest 60 releases (including prereleases).
     """
     try:
-        response = requests.get('https://api.github.com/repos/glueops/codespaces/releases')
+        response = requests.get('https://api.github.com/repos/glueops/codespaces/releases?per_page=60')
         response.raise_for_status()
         releases = response.json()
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Increase release retrieval limit from 5 to 60

- Apply change to both nonprod and prod environments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub API"] --> B["get_codespace_releases()"]
  B --> C["nonprod: 60 releases"]
  B --> D["prod: 60 stable releases"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.py</strong><dd><code>Increase release retrieval limits to 60</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/util/github.py

<ul><li>Updated nonprod environment to retrieve 60 releases instead of 5<br> <li> Updated prod environment to retrieve 60 stable releases instead of 5<br> <li> Modified comments to reflect new limits</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/provisioner/pull/158/files#diff-047285d60c06a65a1fdcee094d06e40beb20c35e049b1a4e5d85c27137d85ece">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

