### PR TITLE
feat!: waggle-backed proxmox placement

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -4,7 +4,9 @@ Operational reference for AI agents working in this repo. Read alongside CLAUDE.
 
 ## Connected Repos
 
-- **[slackbot-developer-workspaces](https://github.com/GlueOps/slackbot-developer-workspaces)** — primary consumer of this API. See its [`.ai/AGENTS.md`](https://github.com/GlueOps/slackbot-developer-workspaces/blob/main/.ai/AGENTS.md) for how it consumes `/v1/regions`, handles the `(Over Allocated)` instance type suffix, and renders Proxmox capacity/load in Slack modals.
+- **[slackbot-developer-workspaces](https://github.com/GlueOps/slackbot-developer-workspaces)** — primary consumer of this API. See its [`.ai/AGENTS.md`](https://github.com/GlueOps/slackbot-developer-workspaces/blob/main/.ai/AGENTS.md) for how it consumes `/v1/regions` (pre-filtered placeable slots) in Slack modals.
+- **[waggle](https://github.com/glueops/waggle)** — the placement oracle behind Proxmox regions. One provisioner region == one Waggle datacenter == one Proxmox cluster; Waggle picks the hypervisor for each VM (anti-affinity, all-or-nothing) and this service provisions it there, then backfills the vmid onto the placement.
+- **[python-glueops-helpers-library](https://github.com/GlueOps/python-glueops-helpers-library)** — provides `glueops.proxmox.ProxmoxClient` (Proxmox REST API: image cache, cloud-init ISO, VM lifecycle, tag discovery, guest agent) and `glueops.waggle.WaggleClient` (datacenters, slots, pools, placements, hypervisor ledger). `app/util/proxmox.py` is a thin orchestration layer over these two clients.
 
 ---
 
@@ -15,7 +17,9 @@ Operational reference for AI agents working in this repo. Read alongside CLAUDE.
 import app.main
 
 # Utility modules
-from app.util import proxmox     # Proxmox VE REST API (image cache, VM lifecycle, guest exec)
+from app.util import proxmox     # Waggle-backed Proxmox orchestration (pool-per-VM placement, VM lifecycle, placeable-slot availability)
+from glueops.proxmox import ProxmoxClient, build_cloudinit_iso   # helpers library: Proxmox REST API client
+from glueops.waggle import WaggleClient                          # helpers library: Waggle API client
 from app.util import virsh       # virsh commands for libvirt VMs
 from app.util import virt        # virt-install VM creation
 from app.util import ssh         # Paramiko SSH execution on remote libvirt hosts
@@ -44,38 +48,44 @@ Do not use `python3` directly, `.venv`, or `devbox shell --`. The `devbox run --
 ### Standard Proxmox cfg for test scripts
 
 ```python
-import asyncio, types, sys
+import asyncio, os, sys
 sys.path.insert(0, "/workspaces/glueops/provisioner")
-from app.util import proxmox
 
-cfg = types.SimpleNamespace(
+# The module reads Waggle + image-server settings from env
+os.environ["WAGGLE_API_URL"] = "<WAGGLE_URL>"
+os.environ["WAGGLE_API_KEY"] = "wgl_..."
+os.environ["PROXMOX_DOWNLOAD_SERVER_URL"] = "<DOWNLOAD_BASE_URL>"
+
+from app.util import proxmox, regions
+
+cfg = regions.ProxmoxConfig(
+    region_name="<REGION_NAME>",                      # == Waggle datacenter name (or set waggle_datacenter_name)
+    enabled=True,
     proxmox_host="<PROXMOX_HOST_OR_IP>",
     proxmox_port=8006,
     proxmox_token_id="<USER>@<REALM>!<TOKENNAME>",   # e.g. root@pam!mytoken
     proxmox_token_secret="<UUID>",                    # UUID only — NOT "tokenname=UUID"
     proxmox_storage="<STORAGE_NAME>",                 # e.g. "local"
     proxmox_bridge="<BRIDGE_NAME>",                   # e.g. "vmbr0"
-    proxmox_vlan_tag=100,                             # VLAN tag applied to net0
+    proxmox_vlan_tag=100,                             # optional; omit for no VLAN tag
     proxmox_verify_ssl=True,                          # set False for self-signed certs
-    region_name="<REGION_NAME>",                      # e.g. "proxmox-cluster-1"
 )
-
-NODE = "<NODE_NAME>"   # e.g. "pve-node-01"
 ```
 
-### Example: validate _agent_exec against a live VM
+### Example: validate guest exec against a live VM
 
 ```python
 async def main():
-    vmid = await proxmox.find_vmid_by_name(cfg, NODE, "my-test-vm")
+    vm = await proxmox.find_vm(cfg, "my-test-vm")     # {node, vmid, name, status}
+    px = proxmox._proxmox(cfg)                        # glueops.proxmox.ProxmoxClient
 
     # Success path — file exists after cloud-init completes
-    out = await proxmox._agent_exec(cfg, NODE, vmid, ["ls", "/var/lib/cloud/instance/boot-finished"])
+    out = await px.agent_exec(vm["node"], vm["vmid"], ["ls", "/var/lib/cloud/instance/boot-finished"])
     print(f"boot-finished: {out!r}")
 
     # Failure path — nonexistent file should raise RuntimeError
     try:
-        await proxmox._agent_exec(cfg, NODE, vmid, ["ls", "/tmp/does-not-exist"])
+        await px.agent_exec(vm["node"], vm["vmid"], ["ls", "/tmp/does-not-exist"])
         print("ERROR: no exception raised")
     except RuntimeError as e:
         print(f"Correctly raised: {e}")
@@ -87,62 +97,39 @@ asyncio.run(main())
 
 ```python
 async def main():
-    import base64, json
-
     user_data = "#cloud-config\npassword: changeme\nchpasswd: {expire: false}\n"
-    meta_data = f"instance-id: test-vm\nlocal-hostname: test-vm\n"
-    iso_bytes = proxmox.build_iso(user_data.encode(), meta_data.encode())
-
-    vmid = await proxmox.get_next_vmid(cfg)
-    iso_filename = None
-    vm_created = False
-    try:
-        await proxmox.ensure_image_cached(cfg, NODE, "<IMAGE_VERSION>", "<DOWNLOAD_BASE_URL>")
-        iso_filename = await proxmox.upload_iso(cfg, NODE, "test-vm", iso_bytes)
-        await proxmox.create_vm(cfg, NODE, vmid, "test-vm", 2, 4096, "<IMAGE_VERSION>", iso_filename, {"owner": "test"})
-        vm_created = True
-        await proxmox.resize_disk(cfg, NODE, vmid, 32000)
-        await proxmox.start_vm(cfg, NODE, vmid)
-        await proxmox.wait_for_cloud_init(cfg, NODE, vmid)
-        print("VM ready")
-    except Exception as e:
-        if vm_created:
-            await proxmox.delete_vm(cfg, NODE, vmid)
-        raise
-    finally:
-        if iso_filename:
-            await proxmox.eject_and_delete_iso(cfg, NODE, vmid, iso_filename)
+    # Waggle picks the hypervisor, provisions, backfills vmid, compensates on failure
+    await proxmox.create(cfg, "test-vm", {"owner": "test"}, user_data,
+                         image="<IMAGE_VERSION>", instance_type="<WAGGLE_SLOT_NAME>")
+    print("VM ready")
+    # cleanup: removes VM by tags and releases its Waggle pool (this datacenter
+    # only); the ISO sweep + image prune run afterwards as a background task
+    await proxmox.delete(cfg, "test-vm")
 
 asyncio.run(main())
 ```
 
 ---
 
-## Proxmox Module Public API
+## Proxmox Module Public API (`app/util/proxmox.py`)
+
+High-level orchestration; all Proxmox/Waggle HTTP calls live in the glueops-helpers clients.
 
 | Function | Signature | Purpose |
 |---|---|---|
-| `get_next_vmid` | `(cfg) -> str` | Next available VMID from cluster |
-| `ensure_image_cached` | `(cfg, node, image, download_url)` | Download qcow2 to import storage if missing |
-| `build_iso` | `(user_data: bytes, meta_data: bytes) -> bytes` | Build cidata ISO with pycdlib |
-| `upload_iso` | `(cfg, node, vm_name, iso_bytes) -> str` | Upload ISO, returns filename |
-| `eject_and_delete_iso` | `(cfg, node, vmid, iso_filename)` | Eject cdrom + delete ISO from storage |
-| `create_vm` | `(cfg, node, vmid, vm_name, vcpus, memory_mb, image, iso_filename, tags)` | Create VM from imported qcow2 |
-| `resize_disk` | `(cfg, node, vmid, storage_mb)` | Resize `virtio0` disk |
-| `start_vm` | `(cfg, node, vmid)` | Start VM, polls task to completion |
-| `stop_vm` | `(cfg, node, vmid)` | Stop VM, polls task to completion |
-| `delete_vm` | `(cfg, node, vmid)` | Stop if running, delete with purge |
-| `wait_for_cloud_init` | `(cfg, node, vmid, agent_timeout=120, cloudinit_timeout=300)` | Two-phase poll: agent up → cloud-init done |
-| `find_vmid_by_name` | `(cfg, node, vm_name) -> str` | Resolve VM name to VMID |
-| `list_vms` | `(cfg) -> list` | All VMs in cluster with decoded tags |
-| `get_nodes_with_capacity` | `(cfg) -> list` | Per-node capacity as list of dicts with `region_name`, capacity fields (`total_vcpus`, `total_memory_gb`, `total_storage_gb`, `free_vcpus`, `free_memory_gb`, `free_storage_gb`), and load fields (`cpu_pct`, `ram_pct`) |
-| `parse_proxmox_region_name` | `(region_name, configs) -> (cfg, node)` | Strip legacy capacity suffix if present, return stable config+node |
-| `edit_vm_tags` | `(cfg, node, vmid, tags)` | Update VM description with encoded tags |
-| `_agent_exec` | `(cfg, node, vmid, command: list[str]) -> str` | Run command in guest via qemu-guest-agent |
+| `get_proxmox_config` | `(region_name, configs) -> ProxmoxConfig \| None` | Exact-match region resolution (backend routing) |
+| `create` | `(cfg, vm_name, tags, user_data, image, instance_type)` | Per-(region,vm_name) lock → datacenter/slot lookup (`UnknownTargetError` → 422) → Waggle pool (`cde-codespaces-{vm_name}`, count 1; failure → `PlacementError` → 409) → placement → image cache → cloud-init ISO → VM create (vmid retry) → best-effort vmid backfill (warn-only) → resize to slot disk_gb → start → wait_for_cloud_init. Compensates (VM + pool) only on failure after provisioning started. No duplicate-name guard by design — callers generate unique names and never retry |
+| `delete` | `(cfg, vm_name)` | Per-(region,vm_name) lock → resolve datacenter (Waggle outage fails before destruction) → delete VM(s) by tags **after verifying the managed-by description marker**; a tagged-but-unmarked VM fails the delete and keeps the pool (no overbooking); vanished VMs and already-gone pools count as success (idempotent retry); pool release filtered to this datacenter's pools only. ISO sweep + image prune run afterwards as a fire-and-forget background task |
+| `_prune_image_cache` | `(cfg)` | Best-effort: prune `cde-codespaces-*` import volumes beyond the newest `PROXMOX_IMAGE_CACHE_KEEP` (default 5) offered versions ∪ in-flight images. Never raises; skipped if the releases fetch fails |
+| `start` / `stop` | `(cfg, vm_name)` | Find by tags, start/stop |
+| `edit_tags` | `(cfg, vm_name, tags)` | Find by tags, rewrite encoded description |
+| `find_vm` | `(cfg, vm_name) -> dict` | `{node, vmid, name, status}` via native tags `[glueops-provisioner, vm_name]` + managed-by description verification, cluster-wide |
+| `list_vms` | `(cfg) -> list` | All managed VMs (creator tag + managed description) in the `/v1/list` contract shape |
+| `get_region` | `(cfg) -> dict` | One region entry: `available_instance_types` = the Waggle slots currently placeable in the datacenter (via `WaggleClient.list_available_slots` — fits on some schedulable hypervisor's bookable capacity) |
 
-Internal helpers available in test scripts (not for production use):
-- `_get`, `_post`, `_put`, `_delete` — raw HTTP wrappers
-- `poll_task(cfg, upid)` — wait for async Proxmox task
+Helpers clients available in test scripts:
+- `proxmox._proxmox(cfg)` — cached `glueops.proxmox.ProxmoxClient` for the region
+- `proxmox._waggle()` — cached `glueops.waggle.WaggleClient` (env-configured)
 
 ---
 
@@ -150,19 +137,25 @@ Internal helpers available in test scripts (not for production use):
 
 These are load-bearing. Do not change without understanding the impact.
 
-1. **`_agent_exec` command is `list[str]`** — Proxmox agent/exec API requires a JSON array. `command.split()` is explicitly avoided — pass `["ls", "/path"]` not `"ls /path"`.
+1. **`agent_exec` command is `list[str]`** — Proxmox agent/exec API requires a JSON array. `command.split()` is explicitly avoided — pass `["ls", "/path"]` not `"ls /path"`.
 
-2. **ISO eject is in `finally`** — `eject_and_delete_iso` always runs regardless of success or failure. Moving it outside `finally` creates ISO leaks on error paths.
+2. **ISO eject is in `finally`** — `eject_and_delete_iso` always runs in `create()` regardless of success or failure. Moving it outside `finally` creates ISO leaks on error paths. `delete()` additionally sweeps `cde-codespaces-{vm_name}-cloudinit.iso` orphans left by crashed creates; the `cde-codespaces-` prefix on ISOs (and cached images) scopes every sweep to resources we own.
 
 3. **`wait_for_cloud_init` runs before `eject_and_delete_iso`** — the cidata ISO must remain mounted until cloud-init reads it on first boot. Order: `start_vm` → `wait_for_cloud_init` → eject (via `finally`).
 
-4. **VM metadata is base64-encoded JSON in the description field** — encode: `b64.encode_string(json.dumps(tags))`; decode: `json.loads(b64.decode_string(desc))`. Both libvirt and Proxmox backends use this format.
+4. **VM metadata is base64-encoded JSON in the description field** — encode: `b64.encode_string(json.dumps(tags))`; decode: `json.loads(b64.decode_string(desc))`. Both libvirt and Proxmox backends use this format. Native Proxmox tags (`glueops-provisioner`, `cde`, `codespaces`, `{vm_name}`) are for discovery/visibility only — user-facing tags live in the description. Identity for find/delete is `glueops-provisioner` + `{vm_name}`; `cde`/`codespaces` are informational and not matched on, so a hand-stripped label can't strand a VM. Tags identify, the description marker *authorizes*: `_is_vm_managed` must pass before any start/stop/edit/delete — a config-fetch error fails the request (never silently skip or act), while a tagged-but-unmarked VM is skipped with a warning.
 
-5. **Proxmox region names are bare `{region_name}-{node}`** — e.g. `proxmox-cluster-1-pve-node-01`. Capacity and load are separate fields on the region object (`total_vcpus`, `free_vcpus`, `cpu_pct`, etc.), never embedded in the name string. `_CAPACITY_SUFFIX` exists only to strip old-format names from external clients — the provisioner itself never generates suffixed names. Always call `parse_proxmox_region_name()` to recover stable `(cfg, node)` — never parse the string manually.
+5. **Proxmox region names are the Waggle datacenter / cluster name** — e.g. `proxmox-cluster-1`. The hypervisor is chosen by Waggle at create time and never appears in the region name. Always resolve regions with `get_proxmox_config()` (exact match). `/v1/regions` carries no capacity fields for Proxmox regions — availability is expressed by which slots are listed.
 
-6. **`serial0: socket` on all Proxmox VMs** — prevents a Debian 12 kernel panic after disk resize. Do not remove from `create_vm`.
+6. **`serial0: socket` on all Proxmox VMs** — prevents a Debian 12 kernel panic after disk resize. Set by `glueops.proxmox.ProxmoxClient.create_vm`; do not override.
 
-7. **`exitcode` check in `_agent_exec`** — a command exiting with non-zero raises `RuntimeError`. The `ls boot-finished` polling loop in `wait_for_cloud_init` depends on this: exit 1/2 (file not found) raises, exit 0 (file exists) returns. The `except RuntimeError` in the polling loop is intentional and load-bearing.
+7. **`exitcode` check in `agent_exec`** — a command exiting with non-zero raises `RuntimeError`. The `ls boot-finished` polling loop in `wait_for_cloud_init` depends on this: exit 1/2 (file not found) raises, exit 0 (file exists) returns. The `except RuntimeError` in the polling loop is intentional and load-bearing.
+
+8. **Waggle pool lifecycle mirrors the VM** — pool `cde-codespaces-{vm_name}` is created before the VM and deleted only after the VM is confirmed gone. If VM deletion fails, keep the pool: Waggle must keep the capacity booked or it will overbook the hypervisor. Never delete the pool first.
+
+9. **Per-(region, vm_name) `asyncio.Lock` serializes create/delete/ISO-sweep** — a delete can't yank the cloud-init ISO from under an in-flight create, and same-name operations never interleave. It serializes only — it does NOT dedupe: a sequential duplicate create is an accepted non-scenario (callers generate unique names and never retry; see CLAUDE.md). These locks (and `_inflight_images`) live in one event loop: the deployment assumption is the single-worker `fastapi run`; multiple workers/replicas would silently disable them.
+
+10. **Image-cache pruning rides on deletes and is strictly best-effort** — cached volumes are labelled `cde-codespaces-{tag}.qcow2` and pruned only from `delete()`, never from the create path. Keep-set = newest `PROXMOX_IMAGE_CACHE_KEEP` offered releases ∪ `_inflight_images` (images a concurrent create is importing — pruning one mid-import fails that create). A prune error only logs; if `get_codespace_releases` fails, the prune is skipped entirely (never prune against an unknown keep-set). Eviction never makes an image unavailable — `ensure_image_cached` re-downloads on demand.
 
 ---
 
@@ -171,7 +164,7 @@ These are load-bearing. Do not change without understanding the impact.
 `wait_for_cloud_init` uses a two-phase approach:
 
 1. Poll `GET /nodes/{node}/qemu/{vmid}/agent/info` every 5s until the guest agent responds (VM has booted, agent is up).
-2. Poll `ls /var/lib/cloud/instance/boot-finished` via `_agent_exec` every 5s until exit code 0.
+2. Poll `ls /var/lib/cloud/instance/boot-finished` via `agent_exec` every 5s until exit code 0.
 
 `boot-finished` is cloud-init's documented final-stage completion marker. It is created after all cloud-init stages (local, network, config, final) have run.
 
@@ -200,7 +193,8 @@ systemctl status qemu-guest-agent
 From a test script against the Proxmox API:
 ```python
 # Run any command in the guest
-out = await proxmox._agent_exec(cfg, NODE, vmid, ["cat", "/var/log/cloud-init.log"])
+vm = await proxmox.find_vm(cfg, "my-test-vm")
+out = await proxmox._proxmox(cfg).agent_exec(vm["node"], vm["vmid"], ["cat", "/var/log/cloud-init.log"])
 print(out[-3000:])  # tail of cloud-init log
 ```
 
@@ -212,8 +206,8 @@ There are no automated tests or linters. Validate changes by:
 
 1. Writing a `test.py` in `/workspaces/glueops/provisioner/` targeting a live VM or cluster.
 2. Running it with `devbox run -- pipenv run python3 test.py`.
-3. For new Proxmox functions: test the happy path, the failure path (bad inputs), and check that compensating actions (delete_vm) fire correctly on exception.
-4. For changes to `wait_for_cloud_init` or `_agent_exec`: test against a running VM with `find_vmid_by_name` — avoid spinning up new VMs just to test small changes.
+3. For new Proxmox functions: test the happy path, the failure path (bad inputs), and check that compensating actions (VM delete + Waggle pool release) fire correctly on exception — and that the pool is *kept* when the VM deletion fails.
+4. For changes to `wait_for_cloud_init` or `agent_exec` behaviour: test against a running VM with `find_vm` — avoid spinning up new VMs just to test small changes.
 
 Delete `test.py` before committing (it typically contains credentials).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Does
 
-Provisioner is a FastAPI service that manages VM lifecycles across distributed regions. It supports two backends: **libvirt** (provisions VMs via virt-install over SSH) and **Proxmox VE** (provisions VMs via the Proxmox REST API). Both backends register VMs with Guacamole for remote access and integrate with Tailscale for networking. All operations are multi-region: requests fan out across configured regions.
+Provisioner is a FastAPI service that manages VM lifecycles across distributed regions. It supports two backends: **libvirt** (provisions VMs via virt-install over SSH) and **Waggle-backed Proxmox VE**. [Waggle](https://github.com/glueops/waggle) is the placement oracle: one provisioner region == one Waggle datacenter == one Proxmox cluster. Creating a VM creates a single-VM Waggle pool, reads back the placement's hypervisor, provisions the VM there via the Proxmox REST API (through the `glueops-helpers` `ProxmoxClient`/`WaggleClient`), and backfills the vmid onto the placement. Both backends register VMs with Guacamole for remote access and integrate with Tailscale for networking. All operations are multi-region: requests fan out across configured regions.
 
 ## Development Commands
 
@@ -34,8 +34,8 @@ There are no automated tests or linting tools configured in this project.
 - `ssh.py` — Paramiko-based SSH execution on remote provisioner nodes; the bridge between this API and remote libvirt hosts
 - `virt.py` — Builds and executes `virt-install` commands for VM creation (cloud-init integration, disk image download + resize)
 - `virsh.py` — Wraps `virsh` commands: destroy, start, undefine, list, edit-tags; list operations run concurrently via `asyncio.to_thread()`
-- `proxmox.py` — All Proxmox VE REST API logic: image caching, pycdlib ISO build/upload/eject, VM create/resize/start/stop/delete, cluster list, tag editing, per-node capacity queries, region name parsing
-- `regions.py` — Parses `BAREMETAL_SERVER_CONFIGS` env var into `RegionBase`, `SSHConfig` (libvirt), and `ProxmoxConfig` Pydantic models
+- `proxmox.py` — Waggle-backed Proxmox orchestration built on `glueops.proxmox.ProxmoxClient` and `glueops.waggle.WaggleClient` (from the glueops-helpers library): pool-per-VM placement, vmid backfill, VM create/start/stop/delete/edit-tags, tag-based VM discovery, placeable-slot availability for `/v1/regions`
+- `regions.py` — Parses `BAREMETAL_SERVER_CONFIGS` env var into `RegionBase`, `SSHConfig` (libvirt), and `ProxmoxConfig` (one Waggle datacenter + the Proxmox credentials to provision into it) Pydantic models
 - `guacamole.py` — Creates/deletes Guacamole connections and grants ownership to the VM creator
 - `tailscale.py` — Removes Tailscale devices when VMs are deleted
 - `github.py` — Fetches available VM images from GitHub releases (filtered by `PROVISIONER_ENVIRONMENT`)
@@ -45,17 +45,19 @@ There are no automated tests or linting tools configured in this project.
 
 ## Key Patterns
 
-**Backend routing:** Each endpoint calls `proxmox.parse_proxmox_region_name()` first; if it matches a Proxmox cluster config the Proxmox path runs, otherwise the libvirt path runs unchanged. Proxmox region names are stable strings of the form `{cluster}-{node}` — e.g. `proxmox-cluster-1-pve-node-01`. Capacity and load data are separate fields on the region object, not embedded in the name.
+**Backend routing:** Each endpoint calls `proxmox.get_proxmox_config()` first; if the region name exactly matches a Proxmox region config the Proxmox path runs, otherwise the libvirt path runs unchanged. A Proxmox region name is the Waggle datacenter / cluster name (e.g. `proxmox-cluster-1`) — the hypervisor is chosen by Waggle at create time and never appears in the region name. Availability is expressed by which slots are listed in `available_instance_types`; the legacy capacity fields on the region object always serialize as `null`.
+
+**Waggle placement (Proxmox creates):** `proxmox.create()` looks up the datacenter (`waggle_datacenter_name`) and the slot named by the request's `instance_type`, creates a Waggle pool named `cde-codespaces-{vm_name}` with `desired_count=1`, and provisions the VM on the placement's hypervisor. The vmid backfill onto the placement is best-effort bookkeeping — a Waggle blip there logs a warning and never triggers compensation against a healthy VM. On real failures the VM (if created) is deleted and the pool released; if the VM deletion itself fails the pool is intentionally kept so Waggle doesn't overbook the hypervisor. Deleting a VM removes it from Proxmox first and only then deletes the Waggle pool, for the same reason. Create and delete are serialized per `(region, vm_name)` via module-level `asyncio.Lock`s (assumes the single-worker `fastapi run` deployment), and delete is idempotent under retry: an already-gone VM or Waggle pool (404) is treated as success. A failed pool create raises `PlacementError` (→ HTTP 409 "at capacity"); unknown datacenter/slot raises `UnknownTargetError` (→ HTTP 422, a dedicated type so a `KeyError` from a malformed Waggle response can't masquerade as a client error). Neither provisions anything nor triggers compensation. There is deliberately no duplicate-name guard on create: callers (the slackbot) generate a unique random name per request and never retry, so an existing-VM check would be dead code — a duplicate create is a known-and-accepted non-scenario. Pool cleanup on delete is scoped to the region's datacenter (`datacenter_id` filter) so a same-named pool elsewhere is never released, and the datacenter is resolved before any destruction so a Waggle outage fails the delete cleanly up front. Every managed VM carries native Proxmox tags `[glueops-provisioner, cde, codespaces, {vm_name}]`; find/start/stop/delete/list match on `glueops-provisioner` + `{vm_name}` only (cluster-wide) — `cde`/`codespaces` are informational labels for the PVE UI and deliberately not part of the identity match. Tags alone don't authorize destruction: before acting on a matched VM, the `managed-by: github.com/GlueOps/provisioner` marker in its description is verified as a second factor (tags are hand-editable in the PVE UI; the description marker is set at create). A tagged-but-unmarked VM is skipped, and the delete then **fails and keeps the Waggle pool** — as long as anything tagged with that name may occupy a hypervisor, the capacity stays booked. `vm_name` and `image` are pattern-validated at the API boundary (`app/schemas/schemas.py`) so they round-trip safely through Proxmox tags, cloud-init YAML, ISO filenames, and URL paths.
 
 **VM metadata storage:** Tags/metadata are JSON-serialized, base64-encoded, and stored in the VM description field. For Proxmox, the description is a YAML document with a human-readable warning header, a `managed-by` key, and a `data` key containing the base64 blob. `_encode_description`/`_decode_description` in `proxmox.py` handle the format; `virsh.py` reads/writes raw base64 for libvirt.
 
-**Multi-region fan-out:** The `/v1/list` endpoint gathers results from all regions concurrently using `asyncio.gather()`. Proxmox regions use `GET /cluster/resources?type=vm`; libvirt regions use `virsh list`. The `/v1/regions` endpoint queries each Proxmox cluster live on every request and expands each cluster into per-node entries, each with a stable `{cluster}-{node}` region name plus separate capacity fields (`total_vcpus`, `free_vcpus`, `total_memory_gb`, `free_memory_gb`, `total_storage_gb`, `free_storage_gb`, `cpu_pct`, `ram_pct`). Libvirt regions return `null` for all capacity fields.
+**Multi-region fan-out:** The `/v1/list` endpoint gathers results from all regions concurrently using `asyncio.gather()`. Proxmox regions find managed VMs by the `glueops-provisioner` native tag; libvirt regions use `virsh list`. The `/v1/regions` endpoint returns one entry per Proxmox region (datacenter) whose `available_instance_types` are the Waggle slots that can currently be placed — a slot is listed iff it fits within the bookable capacity (total − reserved − used) of at least one schedulable hypervisor (`WaggleClient.list_available_slots`). Slot fields map `name`/`vcpu`/`ram_gb`/`disk_gb` → `instance_type`/`vcpus`/`memory_mb`/`storage_mb`. No live Proxmox scans, no per-node region expansion, no capacity fields, and no "(Over Allocated)" instance-type suffix — a listed slot is creatable right now; if capacity races away, pool creation fails all-or-nothing.
 
-**Proxmox cloud-init:** VM creation builds a cidata ISO with pycdlib (Rock Ridge, `vol_ident="cidata"`) containing `user-data` and `meta-data`, uploads it to Proxmox storage, and attaches it as `ide2`. After the VM starts, `wait_for_cloud_init` polls the qemu-guest-agent until `/var/lib/cloud/instance/boot-finished` exists (cloud-init's own completion marker), then the ISO is ejected and deleted. The ISO eject is in a `finally` block — it always runs even if cloud-init times out. `serial0: socket` is set on all Proxmox VMs to prevent a Debian 12 kernel panic after disk resize.
+**Proxmox cloud-init:** VM creation builds a cidata ISO with `glueops.proxmox.build_cloudinit_iso` (pycdlib, Rock Ridge, `vol_ident="cidata"`) containing `user-data` and `meta-data`, uploads it to Proxmox storage, and attaches it as `ide2`. After the VM starts, `ProxmoxClient.wait_for_cloud_init` polls the qemu-guest-agent until `/var/lib/cloud/instance/boot-finished` exists (cloud-init's own completion marker), then the ISO is ejected and deleted. The ISO eject is in a `finally` block — it always runs even if cloud-init times out; after `/v1/delete` responds, a fire-and-forget background task sweeps orphaned `cde-codespaces-{vm_name}-cloudinit.iso` files and prunes the image cache (slow cluster-wide sweeps never delay or fail the user's delete; ISOs carry the same `cde-codespaces-` ownership prefix as cached images, so sweeps only ever match our resources). `serial0: socket` is set on all Proxmox VMs (by the helpers client) to prevent a Debian 12 kernel panic after disk resize.
 
-**Proxmox image caching:** Disk images are downloaded once per node into import storage (`{storage}:import/{image}.qcow2`) and reused across VMs. The cache is never evicted. Concurrent download races are handled by catching 409 and polling until the image appears.
+**Proxmox image caching:** Disk images are downloaded once per node into import storage as `{storage}:import/cde-codespaces-{image}.qcow2` (via `ProxmoxClient.ensure_image_cached` with `cache_name` — the `cde-codespaces-` prefix labels the volumes as ours in the Proxmox UI) and reused across VMs. Concurrent download races are handled by catching 409 and polling until the image appears. The cache is pruned in the background after `/v1/delete` (best-effort, never fails or delays the delete): only the newest `PROXMOX_IMAGE_CACHE_KEEP` (default 5) *offered* versions are kept, plus any image an in-flight create is importing from; the prune regex only matches the `cde-codespaces-` prefix, and the prune is skipped entirely if the GitHub releases fetch fails. Evicted versions that are still offered simply re-download on demand.
 
-**Error handling:** A global FastAPI exception handler returns full stack traces. Individual modules log errors with `glueops.setup_logging.configure()`. Proxmox VM creates include a compensating `delete_vm` if any step after VM definition fails.
+**Error handling:** Client-addressable Proxmox failures map to 4xx with an actionable `detail` (see the Waggle placement pattern above: `UnknownTargetError`→422, `PlacementError`→409, VM-not-found `ValueError`→404); everything else hits the global FastAPI exception handler, which returns full stack traces. Individual modules log errors with `glueops.setup_logging.configure()`. Proxmox VM creates include a compensating cleanup (VM + Waggle pool) if any step after provisioning starts fails.
 
 ## Required Environment Variables
 
@@ -64,20 +66,26 @@ There are no automated tests or linting tools configured in this project.
 | `API_TOKEN` | Bearer token for all API endpoints |
 | `PROVISIONER_ENVIRONMENT` | `prod` or `nonprod` (filters GitHub image releases) |
 | `DOWNLOAD_SERVER_URL` | Base URL for VM disk images (libvirt regions) |
+| `WAGGLE_API_URL` | Base URL of the Waggle server (org-level, shared by all Proxmox regions); required only if any Proxmox region is configured |
+| `WAGGLE_API_KEY` | Waggle org API key (`wgl_...`); required only if any Proxmox region is configured |
 | `PROXMOX_DOWNLOAD_SERVER_URL` | Base URL for VM disk images (Proxmox regions); required only if any Proxmox region is configured |
 | `BAREMETAL_SERVER_CONFIGS` | JSON array of region configs — libvirt (`SSHConfig`) or Proxmox (`ProxmoxConfig`) entries; detected by `backend_type` field (defaults to `"libvirt"`) |
 | `GUACAMOLE_SERVER_URL` / `_USERNAME` / `_PASSWORD` | Guacamole credentials |
-| `BASTION_SERVER_IP` / `_PORT` / `_USER` / `_SSH_KEY` | Bastion host for Guacamole connections |
+| `BASTION_SERVER_IP` / `_PORT` / `_USER` / `_KEY` | Bastion host for Guacamole connections |
+| `PROXMOX_IMAGE_CACHE_KEEP` | Newest N offered image versions kept cached per node (default 5); optional |
 | `TAILSCALE_TAILNET_NAME` / `TAILSCALE_API_TOKEN` | Tailscale integration |
 | `LOG_LEVEL` | Logging level (default: INFO) |
 
 ### Proxmox region config fields
+
+One entry per Waggle datacenter. The datacenter, its hypervisors, and the slots must already exist in Waggle; instance types come from Waggle slots, so there is no `available_instance_types` here. The Proxmox credentials are the provisioner's own (Waggle stores its token write-only and never returns it).
 
 ```json
 {
   "backend_type": "proxmox",
   "region_name": "proxmox-cluster-1",
   "enabled": true,
+  "waggle_datacenter_name": "proxmox-cluster-1",
   "proxmox_host": "1.2.3.4",
   "proxmox_port": 8006,
   "proxmox_token_id": "root@pam!tokenid",
@@ -85,16 +93,11 @@ There are no automated tests or linting tools configured in this project.
   "proxmox_storage": "local",
   "proxmox_bridge": "vmbr_nat",
   "proxmox_vlan_tag": 100,
-  "proxmox_verify_ssl": true,
-  "available_instance_types": [
-    {"instance_type": "2vcpu-8gb-32ssd",    "vcpus": 2,  "memory_mb": 8192,  "storage_mb": 32000},
-    {"instance_type": "4vcpu-8gb-32ssd",    "vcpus": 4,  "memory_mb": 8192,  "storage_mb": 32000},
-    {"instance_type": "4vcpu-16gb-32ssd",   "vcpus": 4,  "memory_mb": 16384, "storage_mb": 32000},
-    {"instance_type": "20vcpu-32gb-120ssd", "vcpus": 20, "memory_mb": 32768, "storage_mb": 120000},
-    {"instance_type": "20vcpu-52gb-120ssd", "vcpus": 20, "memory_mb": 53248, "storage_mb": 120000}
-  ]
+  "proxmox_verify_ssl": true
 }
 ```
+
+`waggle_datacenter_name` defaults to `region_name`; `proxmox_vlan_tag` is optional (omit or `null` for no VLAN tag).
 
 ## CI/CD
 

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 paramiko = "*"
-glueops-helpers = {file = "https://github.com/GlueOps/python-glueops-helpers-library/archive/refs/tags/v0.6.0.zip"}
+glueops-helpers = {file = "https://github.com/GlueOps/python-glueops-helpers-library/archive/refs/tags/v0.8.0.zip"}
 fastapi = {extras = ["standard"], version = "*"}
 httpx = "*"
 pycdlib = "*"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 FastAPI service that manages VM lifecycles across distributed regions. Supports two backends:
 
 - **libvirt** — provisions VMs via virt-install over SSH on remote bare-metal nodes
-- **Proxmox VE** — provisions VMs via the Proxmox REST API
+- **Waggle-backed Proxmox VE** — [Waggle](https://github.com/glueops/waggle) is the placement oracle: one provisioner region == one Waggle datacenter == one Proxmox cluster. Waggle decides which hypervisor each VM lands on (anti-affinity, all-or-nothing); the provisioner then creates the VM on that node via the Proxmox REST API and backfills the vmid onto the Waggle placement. Instance types are Waggle *slots*, pre-filtered against Waggle's hypervisor ledger so `/v1/regions` only lists slots that can be placed right now.
 
 Both backends register VMs with Guacamole for remote access and integrate with Tailscale for networking.
 
@@ -51,6 +51,8 @@ BAREMETAL_SERVER_CONFIGS=         # JSON array of region configs (see below)
 ### Required if any Proxmox region is configured
 
 ```bash
+WAGGLE_API_URL=                   # base URL of the Waggle server (org-level; shared by all Proxmox regions)
+WAGGLE_API_KEY=                   # Waggle org API key (wgl_...)
 PROXMOX_DOWNLOAD_SERVER_URL=      # base URL for VM disk images (Proxmox regions)
 ```
 
@@ -58,6 +60,8 @@ PROXMOX_DOWNLOAD_SERVER_URL=      # base URL for VM disk images (Proxmox regions
 
 ```bash
 LOG_LEVEL=INFO                    # default: INFO
+PROXMOX_IMAGE_CACHE_KEEP=5        # newest N offered image versions kept cached on Proxmox storage (default: 5);
+                                  # older cached versions are pruned during VM deletes and re-download on demand
 ```
 
 ### BAREMETAL_SERVER_CONFIGS format
@@ -80,28 +84,29 @@ A JSON array of region config objects. Each entry is either a libvirt (`SSHConfi
 }
 ```
 
-**Proxmox region:**
+**Proxmox region** (one per Waggle datacenter — the datacenter, hypervisors, and slots must already exist in Waggle):
 ```json
 {
   "backend_type": "proxmox",
   "region_name": "proxmox-cluster-1",
   "enabled": true,
+  "waggle_datacenter_name": "proxmox-cluster-1",
   "proxmox_host": "1.2.3.4",
   "proxmox_port": 8006,
   "proxmox_token_id": "root@pam!tokenid",
   "proxmox_token_secret": "<uuid>",
   "proxmox_storage": "local",
   "proxmox_bridge": "vmbr0",
-  "proxmox_verify_ssl": true,
-  "available_instance_types": [
-    {"instance_type": "2vcpu-8gb-32ssd",    "vcpus": 2,  "memory_mb": 8192,  "storage_mb": 32000},
-    {"instance_type": "4vcpu-16gb-32ssd",   "vcpus": 4,  "memory_mb": 16384, "storage_mb": 32000},
-    {"instance_type": "20vcpu-52gb-120ssd", "vcpus": 20, "memory_mb": 53248, "storage_mb": 120000}
-  ]
+  "proxmox_vlan_tag": null,
+  "proxmox_verify_ssl": true
 }
 ```
 
-Proxmox region names are stable strings of the form `{region_name}-{node}` — e.g. `proxmox-cluster-1-pve-node-01`. Each node entry in the `/v1/regions` response includes separate capacity and load fields: `total_vcpus`, `free_vcpus`, `total_memory_gb`, `free_memory_gb`, `total_storage_gb`, `free_storage_gb`, `cpu_pct`, `ram_pct`.
+- `waggle_datacenter_name` defaults to `region_name` when omitted.
+- The Proxmox credentials here are what the provisioner uses to create VMs — Waggle stores its own Proxmox token write-only for hypervisor discovery and never returns it.
+- No `available_instance_types`: instance types are Waggle slots (org-level, shared by all datacenters).
+
+The Proxmox region name is the cluster/datacenter name (e.g. `proxmox-cluster-1`) — the hypervisor is chosen by Waggle at create time and never appears in the region name. Each region entry in the `/v1/regions` response lists only the Waggle slots that can currently be placed (i.e. fit within the bookable capacity of at least one schedulable hypervisor): if a slot is listed, a VM can be created with it right now.
 
 ---
 
@@ -151,11 +156,21 @@ The provisioner API and its nodes communicate over Tailscale. Example ACL policy
 - Run `install-server.sh` on each provisioner node
 - Assign the appropriate Tailscale tag (e.g. `tag:app-nonprod-provisioner-nodes`)
 
-### Proxmox nodes
+### Onboarding a new Proxmox datacenter
 
-- Proxmox VE 8.x with qemu-guest-agent enabled on VM images
-- API token with sufficient permissions to create/delete/manage VMs
-- Storage pool and network bridge configured per the region config above
+Prerequisites: Proxmox VE **8.4+** (the image cache uses the `download-url` import content type introduced in 8.4), qemu-guest-agent enabled in the VM images, and a storage pool + network bridge configured on every node.
+
+Do these **in order** — the region only works once all of them exist:
+
+1. **Create the datacenter in Waggle** (UI, API, or the terraform provider) with the cluster's PVE API URL and a *read-only* PVE token for discovery. Name it exactly what you'll use as the region's `region_name` (or set `waggle_datacenter_name` explicitly in the region config).
+2. **Run hypervisor discovery** (`POST /datacenters/{id}/discover`). This creates one Waggle hypervisor per Proxmox node with its live capacity.
+3. **Set operator capacity policy per hypervisor**: `reserved` headroom and the `schedulable` flag. Both are preserved across re-discovery; set `schedulable: false` to drain a node for maintenance.
+4. **Ensure slots exist** (org-level, shared by all datacenters). Slot names are exactly the instance types users see in the Slack dropdown; `vcpu`/`ram_gb`/`disk_gb` are what gets provisioned.
+5. **Create a PVE API token for the provisioner** — separate from Waggle's discovery token — with permission to create/delete/configure VMs and upload to the storage pool.
+6. **Add the region entry** to `BAREMETAL_SERVER_CONFIGS` (see format above), set `WAGGLE_API_URL`, `WAGGLE_API_KEY`, and `PROXMOX_DOWNLOAD_SERVER_URL`, and deploy.
+7. **Verify**: `GET /v1/regions` must list the region with the expected slots. A region that silently disappears from the response means its Waggle lookup failed — check the provisioner logs for `Skipping region <name>`.
+
+> ⚠️ **Load-bearing invariant: Waggle hypervisor names must equal Proxmox node names.** The provisioner uses a placement's `hypervisor_name` verbatim as the node in Proxmox API paths. Discovery guarantees this automatically — never hand-create hypervisor entries in Waggle with different names, or every create in that datacenter will fail.
 
 ---
 

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi.security import APIKeyHeader
 from typing import Optional, Dict, List
 from pydantic import BaseModel, Field
 from util import ssh, virt, virsh, formatter, b64, regions, github, guacamole, tailscale, proxmox
-import os, glueops.setup_logging, traceback, base64, yaml, tempfile, json, asyncio, random
+import os, glueops.setup_logging, traceback, base64, yaml, tempfile, json, asyncio
 from schemas.schemas import ExistingVm, Vm, VmMeta, Message, VmTags
 
 
@@ -31,10 +31,11 @@ except KeyError as e:
     logger.critical(f"Required environment variable {e} is not set")
     raise SystemExit(1)
 
-PROXMOX_DOWNLOAD_SERVER_URL = os.environ.get('PROXMOX_DOWNLOAD_SERVER_URL')
-if HAS_PROXMOX and not PROXMOX_DOWNLOAD_SERVER_URL:
-    logger.critical("PROXMOX_DOWNLOAD_SERVER_URL is required when Proxmox regions are configured")
-    raise SystemExit(1)
+if HAS_PROXMOX:
+    _missing = [k for k in ('WAGGLE_API_URL', 'WAGGLE_API_KEY', 'PROXMOX_DOWNLOAD_SERVER_URL') if not os.environ.get(k)]
+    if _missing:
+        logger.critical(f"Required when Proxmox regions are configured but not set: {', '.join(_missing)}")
+        raise SystemExit(1)
 
 api_key_header = APIKeyHeader(name="Authorization")
 
@@ -88,7 +89,12 @@ def _remove_guacamole_and_tailscale(vm_name: str):
 
 @app.post("/v1/create", response_model=Message)
 async def create_vm(vm: Vm, api_key: str = Depends(get_api_key)):
-    logger.info(vm)
+    # Deliberately NOT logging the full payload: user_data carries profile
+    # secrets (e.g. GITHUB_TOKEN) and tags carry cde_token.
+    logger.info(
+        f"Create request: vm_name={vm.vm_name} region={vm.region_name} "
+        f"instance_type={vm.instance_type} image={vm.image} tag_keys={sorted(vm.tags)}"
+    )
     decoded_user_data = formatter.fix_indentation(base64.b64decode(vm.user_data).decode('utf-8').strip())
     try:
         yaml.safe_load(decoded_user_data)
@@ -96,53 +102,13 @@ async def create_vm(vm: Vm, api_key: str = Depends(get_api_key)):
         raise ValueError(f"Invalid YAML in user data: {e}")
 
     # Resolve backend
-    proxmox_cfg, node = None, None
-    try:
-        proxmox_cfg, node = proxmox.parse_proxmox_region_name(vm.region_name, REGIONS)
-    except ValueError:
-        pass
+    proxmox_cfg = proxmox.get_proxmox_config(vm.region_name, REGIONS)
 
     if proxmox_cfg is not None:
-        instance_type = vm.instance_type.removesuffix(proxmox._OVER_ALLOCATED)
-        vm_specs = next(
-            (it for it in proxmox_cfg.available_instance_types if it.instance_type == instance_type),
-            None
-        )
-        if vm_specs is None:
-            raise ValueError(f"Instance type {vm.instance_type} not found in region {vm.region_name}")
-
-        vmid = None
-        iso_filename = None
-        vm_created = False
         try:
-            await proxmox.ensure_image_cached(proxmox_cfg, node, vm.image, PROXMOX_DOWNLOAD_SERVER_URL)
-            meta_data = f"instance-id: {vm.vm_name}\nlocal-hostname: {vm.vm_name}\n"
-            iso_bytes = proxmox.build_iso(decoded_user_data.encode(), meta_data.encode())
-            iso_filename = await proxmox.upload_iso(proxmox_cfg, node, vm.vm_name, iso_bytes)
-            for attempt in range(5):
-                vmid = await proxmox.get_next_vmid(proxmox_cfg)
-                try:
-                    await proxmox.create_vm(proxmox_cfg, node, vmid, vm.vm_name, vm_specs.vcpus, vm_specs.memory_mb, vm.image, iso_filename, vm.tags)
-                    break
-                except Exception as e:
-                    if attempt < 4 and ("already exists" in str(e) or "can't lock file" in str(e)):
-                        logger.warning(f"VMID {vmid} conflict on attempt {attempt + 1}, retrying")
-                        continue
-                    raise
-            vm_created = True
-            for attempt in range(5):
-                try:
-                    await proxmox.resize_disk(proxmox_cfg, node, vmid, vm_specs.storage_mb)
-                    break
-                except Exception as e:
-                    if attempt < 4 and "got timeout" in str(e):
-                        delay = (2 ** attempt) * 5 + random.uniform(0, 5)
-                        logger.warning(f"resize_disk timeout for VM {vmid} on attempt {attempt + 1}, retrying in {delay:.1f}s")
-                        await asyncio.sleep(delay)
-                        continue
-                    raise
-            await proxmox.start_vm(proxmox_cfg, node, vmid)
-            await proxmox.wait_for_cloud_init(proxmox_cfg, node, vmid)
+            # Waggle resolves vm.instance_type to a slot and picks the hypervisor;
+            # proxmox.create compensates internally (VM + Waggle pool) on failure.
+            await proxmox.create(proxmox_cfg, vm.vm_name, vm.tags, decoded_user_data, vm.image, vm.instance_type)
 
             guacamole_token, data_source = guacamole.get_data(GUACAMOLE_SERVER_URL, GUACAMOLE_SERVER_USERNAME, GUACAMOLE_SERVER_PASSWORD)
             connection_groups = guacamole.get_connection_groups(GUACAMOLE_SERVER_URL, guacamole_token, data_source)
@@ -151,18 +117,20 @@ async def create_vm(vm: Vm, api_key: str = Depends(get_api_key)):
             vm_id = guacamole.create_vm(GUACAMOLE_SERVER_URL, guacamole_token, data_source, connection_group_id, vm.vm_name, BASTION_SERVER_IP, BASTION_SERVER_PORT, BASTION_SERVER_USER, BASTION_SERVER_KEY)
             if owner:
                 guacamole.grant_connection_permission(GUACAMOLE_SERVER_URL, guacamole_token, data_source, owner, vm_id)
+        except proxmox.UnknownTargetError as e:
+            # Unknown datacenter/slot — nothing was provisioned, no compensation
+            raise HTTPException(status_code=422, detail=str(e))
+        except proxmox.PlacementError as e:
+            # Region can't place the VM (at capacity) — nothing was provisioned
+            raise HTTPException(status_code=409, detail=str(e))
         except Exception:
-            if vm_created:
-                try:
-                    await proxmox.delete_vm(proxmox_cfg, node, vmid)
-                except Exception as cleanup_err:
-                    logger.error(f"Compensating delete failed for VM {vmid}: {cleanup_err}")
+            # Idempotent: removes the VM (if any) and its Waggle pool
+            try:
+                await proxmox.delete(proxmox_cfg, vm.vm_name)
+            except Exception as cleanup_err:
+                logger.error(f"Compensating cleanup failed for VM {vm.vm_name}: {cleanup_err}")
             raise
-        finally:
-            if iso_filename and vmid:
-                await proxmox.eject_and_delete_iso(proxmox_cfg, node, vmid, iso_filename)
 
-        logger.info(vm.tags)
         return JSONResponse(status_code=200, content={"message": "Success"})
 
     # Libvirt path
@@ -229,7 +197,7 @@ async def create_vm(vm: Vm, api_key: str = Depends(get_api_key)):
             os.remove(meta_temp_file_path)
             logger.info(f"Meta Data temporary file deleted: {meta_temp_file_path}")
 
-    logger.info(vm.tags)
+    logger.info(f"Created libvirt VM {vm.vm_name} with tag keys {sorted(vm.tags)}")
     return JSONResponse(status_code=200, content={"message": "Success"})
 
 
@@ -238,8 +206,13 @@ async def list_regions(api_key: str = Depends(get_api_key)):
     result = []
     for cfg in regions.get_enabled_regions_only(REGIONS):
         if getattr(cfg, "backend_type", "libvirt") == "proxmox":
-            nodes = await proxmox.get_nodes_with_capacity(cfg)
-            result.extend(nodes)
+            # One unreachable Waggle/misconfigured region must not take down
+            # the whole endpoint (and with it the create modal) for the
+            # healthy regions — degrade by skipping it.
+            try:
+                result.append(await proxmox.get_region(cfg))
+            except Exception as e:
+                logger.error(f"Skipping region {cfg.region_name} in /v1/regions: {e}")
         else:
             result.append(cfg)
     return result
@@ -274,14 +247,12 @@ async def list_vms(api_key: str = Depends(get_api_key)):
 
 @app.post("/v1/start", response_model=Message)
 async def start_vm(vm: VmMeta, api_key: str = Depends(get_api_key)):
-    try:
-        proxmox_cfg, node = proxmox.parse_proxmox_region_name(vm.region_name, REGIONS)
-    except ValueError:
-        proxmox_cfg, node = None, None
-
+    proxmox_cfg = proxmox.get_proxmox_config(vm.region_name, REGIONS)
     if proxmox_cfg is not None:
-        vmid = await proxmox.find_vmid_by_name(proxmox_cfg, node, vm.vm_name)
-        await proxmox.start_vm(proxmox_cfg, node, vmid)
+        try:
+            await proxmox.start(proxmox_cfg, vm.vm_name)
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
     else:
         cfg = regions.get_server_config(vm.region_name, REGIONS)
         virsh.start_vm(cfg.connect_uri, vm.vm_name)
@@ -290,14 +261,12 @@ async def start_vm(vm: VmMeta, api_key: str = Depends(get_api_key)):
 
 @app.post("/v1/stop", response_model=Message)
 async def stop_vm(vm: VmMeta, api_key: str = Depends(get_api_key)):
-    try:
-        proxmox_cfg, node = proxmox.parse_proxmox_region_name(vm.region_name, REGIONS)
-    except ValueError:
-        proxmox_cfg, node = None, None
-
+    proxmox_cfg = proxmox.get_proxmox_config(vm.region_name, REGIONS)
     if proxmox_cfg is not None:
-        vmid = await proxmox.find_vmid_by_name(proxmox_cfg, node, vm.vm_name)
-        await proxmox.stop_vm(proxmox_cfg, node, vmid)
+        try:
+            await proxmox.stop(proxmox_cfg, vm.vm_name)
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
     else:
         cfg = regions.get_server_config(vm.region_name, REGIONS)
         virsh.destroy_vm(cfg.connect_uri, vm.vm_name)
@@ -306,14 +275,12 @@ async def stop_vm(vm: VmMeta, api_key: str = Depends(get_api_key)):
 
 @app.post("/v1/edit-tags", response_model=Message)
 async def edit_vm_tags(vm: VmTags, api_key: str = Depends(get_api_key)):
-    try:
-        proxmox_cfg, node = proxmox.parse_proxmox_region_name(vm.region_name, REGIONS)
-    except ValueError:
-        proxmox_cfg, node = None, None
-
+    proxmox_cfg = proxmox.get_proxmox_config(vm.region_name, REGIONS)
     if proxmox_cfg is not None:
-        vmid = await proxmox.find_vmid_by_name(proxmox_cfg, node, vm.vm_name)
-        await proxmox.edit_vm_tags(proxmox_cfg, node, vmid, vm.tags)
+        try:
+            await proxmox.edit_tags(proxmox_cfg, vm.vm_name, vm.tags)
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
     else:
         cfg = regions.get_server_config(vm.region_name, REGIONS)
         virsh.edit_vm_tags(cfg.connect_uri, vm.vm_name, vm.tags)
@@ -322,16 +289,11 @@ async def edit_vm_tags(vm: VmTags, api_key: str = Depends(get_api_key)):
 
 @app.delete("/v1/delete", response_model=Message)
 async def delete_vm(vm: VmMeta, api_key: str = Depends(get_api_key)):
-    try:
-        proxmox_cfg, node = proxmox.parse_proxmox_region_name(vm.region_name, REGIONS)
-    except ValueError:
-        proxmox_cfg, node = None, None
-
+    proxmox_cfg = proxmox.get_proxmox_config(vm.region_name, REGIONS)
     if proxmox_cfg is not None:
-        vmid = await proxmox.find_vmid_by_name(proxmox_cfg, node, vm.vm_name)
         try:
             _remove_guacamole_and_tailscale(vm.vm_name)
-            await proxmox.delete_vm(proxmox_cfg, node, vmid)
+            await proxmox.delete(proxmox_cfg, vm.vm_name)
         except Exception as e:
             logger.error(f"Failed to delete VM {vm.vm_name}: {e}")
             raise

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -1,6 +1,14 @@
 from pydantic import BaseModel, Field
 from typing import Dict
 
+# vm_name flows into Proxmox native tags (";"/"," are tag separators there),
+# cloud-init meta-data YAML, ISO filenames, and Waggle pool names — restrict it
+# to safe DNS-style names so it round-trips verbatim through all of them.
+VM_NAME_PATTERN = r'^[a-z0-9][a-z0-9.-]{0,62}$'
+# image becomes a URL path segment on the download server and a PVE storage
+# filename — release-tag charset only (no path separators or traversal).
+IMAGE_PATTERN = r'^v[0-9A-Za-z._-]{1,63}$'
+
 class ExistingVm(BaseModel):
     dom_id: str = Field(...,example = "1")
     name: str = Field(...,example = 'dinosaur-cat')
@@ -9,21 +17,21 @@ class ExistingVm(BaseModel):
     tags: Dict[str, str] = Field(...,example = {"customkey1": "customvalue1", "customkey2": "customvalue2", "customkey3": "customvalue3"})
 
 class Vm(BaseModel):
-    vm_name: str = Field(...,example = 'dinosaur-cat')
+    vm_name: str = Field(...,pattern = VM_NAME_PATTERN, example = 'dinosaur-cat')
     tags: dict = Field(...,example = {"owner": "john.doe@example.com"})
     user_data: str = Field(...,example = 'I2Nsb3VkLWNvbmZpZwpydW5jbWQ6CiAgLSBbJ3Bhc3N3ZCcsICctZCcsICdkZWJpYW4nXQo=')
-    image: str = Field(...,example = 'v0.76.0')
+    image: str = Field(...,pattern = IMAGE_PATTERN, example = 'v0.76.0')
     region_name: str = Field(...,example = 'andromeda')
     instance_type: str = Field(...,example = 'basic')
 
 class VmMeta(BaseModel):
-    vm_name: str = Field(...,example = 'dinosaur-cat')
+    vm_name: str = Field(...,pattern = VM_NAME_PATTERN, example = 'dinosaur-cat')
     region_name: str = Field(...,example = 'andromeda')
 
 class Message(BaseModel):
     message: str = Field(...,example = 'Success')
 
 class VmTags(BaseModel):
-    vm_name: str = Field(...,example = 'dinosaur-cat')
+    vm_name: str = Field(...,pattern = VM_NAME_PATTERN, example = 'dinosaur-cat')
     region_name: str = Field(...,example = 'andromeda')
     tags: dict = Field(...,example = {"owner": "john.doe@example.com", "description": "New vm description"})

--- a/app/util/proxmox.py
+++ b/app/util/proxmox.py
@@ -1,9 +1,80 @@
-import asyncio, io, re, json, urllib.parse, os, yaml
-import httpx, pycdlib
+"""Waggle-backed Proxmox VM orchestration.
+
+Waggle (the placement oracle) decides which hypervisor each VM lands on:
+one provisioner region == one Waggle datacenter == one Proxmox cluster.
+Creating a VM creates a single-VM Waggle pool, reads back the placement's
+hypervisor, provisions the VM there via the Proxmox API (glueops helpers),
+and backfills the vmid onto the placement. Deleting a VM removes it from
+Proxmox first and only then releases the Waggle pool, so Waggle can never
+overbook a hypervisor that still holds the VM.
+
+Instance types are Waggle slots (name, vcpu, ram_gb, disk_gb); the slots
+offered by /v1/regions are pre-filtered against Waggle's hypervisor ledger
+(a slot is listed iff it fits some schedulable hypervisor's bookable
+capacity) instead of live Proxmox scans.
+"""
+
+import asyncio, json, os, random, re, yaml
+from collections import Counter
 import glueops.setup_logging
-from . import b64
+from glueops.proxmox import ProxmoxClient, build_cloudinit_iso
+from glueops.waggle import WaggleClient
+from . import b64, github
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+logger = glueops.setup_logging.configure(level=LOG_LEVEL)
 
 _MANAGED_BY = "github.com/GlueOps/provisioner"
+# Native Proxmox tag on every VM we create; find/delete match on
+# [CREATOR_TAG, vm_name] so no other tool's VMs are ever touched.
+CREATOR_TAG = "glueops-provisioner"
+# Additional informational tags for visibility/filtering in the PVE UI.
+# Deliberately NOT part of the find/delete match: identity is CREATOR_TAG +
+# vm_name, so a hand-stripped label can't strand a VM from the API.
+EXTRA_TAGS = ("cde", "codespaces")
+# Everything we create outside the VM itself is labelled with this prefix so
+# ownership is obvious at a glance and every sweep/lookup only ever matches
+# our own resources:
+#   Waggle pools:        cde-codespaces-{vm_name}
+#   cached images:       {storage}:import/cde-codespaces-v0.143.0.qcow2
+#   cloud-init ISOs:     {storage}:iso/cde-codespaces-{vm_name}-cloudinit.iso
+_CDE_PREFIX = "cde-codespaces-"
+# Keep the newest N offered image versions cached; older ones are pruned on
+# delete and simply re-download on demand if requested again.
+_IMAGE_CACHE_KEEP = int(os.getenv("PROXMOX_IMAGE_CACHE_KEEP", "5"))
+
+_waggle_client = None
+_proxmox_clients = {}  # region_name -> ProxmoxClient
+# region_name -> Counter of cached-image names used by in-flight creates;
+# the prune keep-set includes these so a concurrent create's import source
+# is never deleted out from under it.
+_inflight_images = {}
+# (region_name, vm_name) -> asyncio.Lock serializing create/delete (and the
+# background ISO sweep) per VM, so a retry-during-create can't build a
+# duplicate pool/VM and a delete can't yank the ISO from under an in-flight
+# create. NOTE: this lock and _inflight_images guard within ONE event loop —
+# they assume the single-worker `fastapi run` deployment; running multiple
+# workers or replicas would silently disable them.
+_vm_locks = {}
+# Strong refs to fire-and-forget cleanup tasks (asyncio only keeps weak ones).
+_background_tasks = set()
+
+
+class PlacementError(RuntimeError):
+    """Waggle could not place the VM (pool create failed all-or-nothing —
+    typically the datacenter is at capacity for the requested slot)."""
+
+
+class UnknownTargetError(Exception):
+    """The configured datacenter or requested slot doesn't exist in Waggle.
+    Nothing was provisioned. Deliberately NOT a LookupError subclass mapping:
+    a KeyError from a malformed Waggle response (KeyError ⊂ LookupError) must
+    surface as a 500, not masquerade as client error 422."""
+
+
+def _vm_lock(cfg, vm_name: str) -> asyncio.Lock:
+    return _vm_locks.setdefault((cfg.region_name, vm_name), asyncio.Lock())
+
 
 def _encode_description(tags: dict) -> str:
     return (
@@ -12,331 +83,404 @@ def _encode_description(tags: dict) -> str:
         f"data: {b64.encode_string(json.dumps(tags))}"
     )
 
+
+# Our encoded descriptions are far smaller than this; anything bigger is a
+# hand-edited description and gets rejected before yaml parsing, which caps
+# YAML anchor/alias expansion tricks.
+_MAX_DESCRIPTION_BYTES = 16384
+
+
 def _is_managed(desc: str) -> bool:
+    if len(desc) > _MAX_DESCRIPTION_BYTES:
+        return False
     try:
         parsed = yaml.safe_load(desc)
         return isinstance(parsed, dict) and parsed.get("managed-by") == _MANAGED_BY
     except Exception:
         return False
 
+
 def _decode_description(desc: str) -> dict:
+    if len(desc) > _MAX_DESCRIPTION_BYTES:
+        return {}
     parsed = yaml.safe_load(desc)
     if isinstance(parsed, dict) and parsed.get("managed-by") == _MANAGED_BY and "data" in parsed:
         return json.loads(b64.decode_string(parsed["data"]))
     return {}
 
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
-logger = glueops.setup_logging.configure(level=LOG_LEVEL)
 
-# Kept for backwards compatibility — strips old capacity suffixes from region names
-# passed in by external clients. The provisioner itself no longer generates suffixed names.
-_CAPACITY_SUFFIX = re.compile(r' \(\d+ vCPU, \d+GB RAM, \d+GB Disk\)$')
-_OVER_ALLOCATED = " (Over Allocated)"
+def _pool_name(vm_name: str) -> str:
+    return f"{_CDE_PREFIX}{vm_name}"
 
 
-def _client(cfg):
-    if not cfg.proxmox_verify_ssl:
-        logger.warning(f"SSL verification disabled for {cfg.proxmox_host}")
-    headers = {"Authorization": f"PVEAPIToken={cfg.proxmox_token_id}={cfg.proxmox_token_secret}"}
-    return httpx.AsyncClient(verify=cfg.proxmox_verify_ssl, timeout=30.0, headers=headers)
+def _waggle() -> WaggleClient:
+    global _waggle_client
+    if _waggle_client is None:
+        _waggle_client = WaggleClient(os.environ["WAGGLE_API_URL"], os.environ["WAGGLE_API_KEY"])
+    return _waggle_client
 
 
-def _base(cfg):
-    return f"https://{cfg.proxmox_host}:{cfg.proxmox_port}/api2/json"
+def _proxmox(cfg) -> ProxmoxClient:
+    px = _proxmox_clients.get(cfg.region_name)
+    if px is None:
+        px = ProxmoxClient(
+            host=cfg.proxmox_host,
+            token_id=cfg.proxmox_token_id,
+            token_secret=cfg.proxmox_token_secret,
+            storage=cfg.proxmox_storage,
+            port=cfg.proxmox_port,
+            verify_ssl=cfg.proxmox_verify_ssl,
+            download_server_url=os.environ.get("PROXMOX_DOWNLOAD_SERVER_URL"),
+        )
+        _proxmox_clients[cfg.region_name] = px
+    return px
 
 
-async def _get(cfg, path, **params):
-    async with _client(cfg) as c:
-        r = await c.get(f"{_base(cfg)}{path}", params=params or None)
-        r.raise_for_status()
-        return r.json()["data"]
+def get_proxmox_config(region_name: str, configs: list):
+    """Return the ProxmoxConfig whose region_name matches exactly, else None."""
+    for cfg in configs:
+        if getattr(cfg, "backend_type", "libvirt") == "proxmox" and cfg.region_name == region_name:
+            return cfg
+    return None
 
 
-async def _post(cfg, path, data=None, files=None):
-    async with _client(cfg) as c:
-        r = await c.post(f"{_base(cfg)}{path}", data=data, files=files)
-        r.raise_for_status()
-        return r.json()["data"]
+async def _is_vm_managed(px, vm):
+    """Second authorization factor before acting on a VM: native tags are
+    hand-editable in the PVE UI, so additionally require the managed-by marker
+    in the description (set at create, not casually editable).
 
-
-async def _put(cfg, path, data):
-    async with _client(cfg) as c:
-        r = await c.put(f"{_base(cfg)}{path}", data=data)
-        r.raise_for_status()
-        return r.json()["data"]
-
-
-async def _delete(cfg, path, **params):
-    async with _client(cfg) as c:
-        r = await c.delete(f"{_base(cfg)}{path}", params=params or None)
-        r.raise_for_status()
-        return r.json()["data"]
-
-
-async def poll_task(cfg, upid: str):
-    task_node = upid.split(":")[1]
-    encoded = urllib.parse.quote(upid, safe="")
-    while True:
-        data = await _get(cfg, f"/nodes/{task_node}/tasks/{encoded}/status")
-        if data["status"] == "stopped":
-            if data.get("exitstatus") != "OK":
-                raise RuntimeError(f"Task failed: {data}")
-            return
-        await asyncio.sleep(3)
-
-
-async def get_next_vmid(cfg) -> str:
-    return await _get(cfg, "/cluster/nextid")
-
-
-async def ensure_image_cached(cfg, node: str, image: str, download_url: str):
-    content = await _get(cfg, f"/nodes/{node}/storage/{cfg.proxmox_storage}/content", content="import")
-    volid = f"{cfg.proxmox_storage}:import/{image}.qcow2"
-    if volid in {v["volid"] for v in (content or [])}:
-        logger.info(f"Image {image} already cached on {node}")
-        return
-    logger.info(f"Downloading {image} to {node}")
+    Returns True (managed), False (tagged but unmarked — do not touch), or
+    None (the VM vanished between listing and this check — already deleted).
+    Any other config-fetch error propagates — an unverifiable VM must fail the
+    request, not be silently skipped or acted on."""
     try:
-        upid = await _post(cfg, f"/nodes/{node}/storage/{cfg.proxmox_storage}/download-url", data={
-            "url": f"{download_url.rstrip('/')}/{image}.qcow2",
-            "filename": f"{image}.qcow2",
-            "content": "import",
-        })
-        await poll_task(cfg, upid)
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 409:
-            # Another download already in progress — wait for it to complete
-            logger.info(f"Image {image} download already in progress on {node}, waiting...")
-            for _ in range(60):
-                await asyncio.sleep(5)
-                content = await _get(cfg, f"/nodes/{node}/storage/{cfg.proxmox_storage}/content", content="import")
-                if volid in {v["volid"] for v in (content or [])}:
-                    return
-            raise RuntimeError(f"Timed out waiting for {image} to become available on {node}")
+        config = await px.get_vm_config(vm["node"], vm["vmid"])
+    except Exception as e:
+        if ProxmoxClient._is_missing_vm_error(e):
+            return None
+        raise
+    return _is_managed(config.get("description", ""))
+
+
+async def find_vm(cfg, vm_name: str) -> dict:
+    """Return {node, vmid, name, status} for the managed VM, cluster-wide.
+    Requires both the native tags and the managed-by description marker."""
+    px = _proxmox(cfg)
+    for vm in await px.list_vms_by_tags([CREATOR_TAG, vm_name]):
+        managed = await _is_vm_managed(px, vm)
+        if managed:
+            return vm
+        if managed is False:
+            logger.warning(
+                f"VM {vm['vmid']} on {vm['node']} carries tags [{CREATOR_TAG}, {vm_name}] "
+                f"but not the managed-by description marker; ignoring it"
+            )
+    raise ValueError(f"VM {vm_name!r} not found in region {cfg.region_name}")
+
+
+async def create(cfg, vm_name: str, tags: dict, user_data: str, image: str, instance_type: str):
+    """Create one VM: Waggle picks the hypervisor, Proxmox runs the VM.
+    Serialized per (region, vm_name) against concurrent create/delete.
+
+    Raises UnknownTargetError (unknown datacenter/slot — nothing was
+    provisioned) or PlacementError (Waggle couldn't place the VM — nothing
+    was provisioned).
+    On any later failure the VM (if created) is deleted and the Waggle pool
+    released; if the VM deletion itself fails, the pool is kept on purpose so
+    Waggle doesn't hand the reserved capacity to someone else.
+    """
+    async with _vm_lock(cfg, vm_name):
+        await _create_locked(cfg, vm_name, tags, user_data, image, instance_type)
+
+
+async def _create_locked(cfg, vm_name: str, tags: dict, user_data: str, image: str, instance_type: str):
+    waggle = _waggle()
+    px = _proxmox(cfg)
+    try:
+        datacenter = await waggle.get_datacenter_by_name(cfg.waggle_datacenter_name)
+        slot = await waggle.get_slot_by_name(instance_type)
+    except LookupError as e:
+        raise UnknownTargetError(str(e)) from e
+
+    # Subscript OUTSIDE the try: a malformed Waggle response (KeyError) must
+    # surface as an internal error, not be swallowed into PlacementError/409.
+    datacenter_id = datacenter["id"]
+    slot_id = slot["id"]
+    try:
+        pool = await waggle.create_pool(datacenter_id, slot_id, _pool_name(vm_name), 1)
+    except Exception as e:
+        # All-or-nothing placement: a failed pool create provisioned nothing.
+        # Collapse the wrapped error to one trimmed line — this text travels
+        # to the Slack user via the 409 detail.
+        err_text = " ".join(str(e).split())[:200]
+        raise PlacementError(
+            f"Waggle could not place a {instance_type!r} VM in {cfg.region_name} "
+            f"(likely at capacity): {err_text}"
+        ) from e
+
+    cached_image = f"{_CDE_PREFIX}{image}"
+    inflight = _inflight_images.setdefault(cfg.region_name, Counter())
+    inflight[cached_image] += 1
+
+    node = None
+    vmid = None
+    iso_filename = None
+    vm_created = False
+    try:
+        placements = await waggle.get_pool_placements(pool["id"])
+        if not placements:
+            raise RuntimeError(f"Waggle pool {pool['id']} has no placements")
+        placement = placements[0]
+        node = placement["hypervisor_name"]
+        logger.info(f"Waggle placed VM {vm_name} on hypervisor {node} in {cfg.region_name}")
+
+        await px.ensure_image_cached(node, image, cache_name=cached_image)
+        meta_data = f"instance-id: {vm_name}\nlocal-hostname: {vm_name}\n"
+        iso_bytes = build_cloudinit_iso(user_data.encode(), meta_data.encode())
+        iso_filename = await px.upload_iso(node, f"{_CDE_PREFIX}{vm_name}-cloudinit.iso", iso_bytes)
+
+        # get_next_vmid is non-reserving; retry on collision with a concurrent create
+        for attempt in range(5):
+            vmid = await px.get_next_vmid()
+            try:
+                await px.create_vm(
+                    node=node,
+                    vmid=vmid,
+                    vm_name=vm_name,
+                    vcpus=slot["vcpu"],
+                    memory_mb=slot["ram_gb"] * 1024,
+                    image=cached_image,
+                    iso_filename=iso_filename,
+                    bridge=cfg.proxmox_bridge,
+                    vlan_tag=cfg.proxmox_vlan_tag,
+                    tags=[CREATOR_TAG, *EXTRA_TAGS, vm_name],
+                    description=_encode_description(tags),
+                )
+                break
+            except Exception as e:
+                if attempt < 4 and ("already exist" in str(e) or "can't lock file" in str(e)):
+                    logger.warning(f"VMID {vmid} conflict on attempt {attempt + 1}, retrying")
+                    continue
+                raise
+        vm_created = True
+        try:
+            await waggle.set_placement_vmid(placement["id"], int(vmid))
+        except Exception as e:
+            # Ledger bookkeeping only — a Waggle blip here must not trigger
+            # compensation that destroys a perfectly healthy VM. Discovery
+            # still reconciles used capacity; the placement just lacks a vmid.
+            logger.warning(f"Failed to backfill vmid {vmid} onto placement {placement['id']}: {e}")
+
+        for attempt in range(5):
+            try:
+                await px.resize_disk(node, vmid, disk_gb=slot["disk_gb"])
+                break
+            except Exception as e:
+                if attempt < 4 and "got timeout" in str(e):
+                    delay = (2 ** attempt) * 5 + random.uniform(0, 5)
+                    logger.warning(f"resize_disk timeout for VM {vmid} on attempt {attempt + 1}, retrying in {delay:.1f}s")
+                    await asyncio.sleep(delay)
+                    continue
+                raise
+        await px.start_vm(node, vmid)
+        try:
+            await px.wait_for_cloud_init(node, vmid)
+        except RuntimeError as e:
+            # Guest agent never came up — the VM may still be usable; the
+            # cloud-init ISO is ejected in the finally block regardless.
+            logger.warning(f"VM {vmid}: {e}")
+    except Exception:
+        try:
+            if vm_created:
+                await px.delete_vm(node, vmid)
+            await waggle.delete_pool(pool["id"])
+        except Exception as cleanup_err:
+            logger.error(f"Compensating cleanup failed for VM {vm_name}: {cleanup_err}")
+        raise
+    finally:
+        inflight[cached_image] -= 1
+        if inflight[cached_image] <= 0:
+            del inflight[cached_image]
+        if iso_filename and vmid:
+            await px.eject_and_delete_iso(node, vmid, iso_filename)
+
+
+def _reraise_if_vm_vanished(e: Exception, cfg, vm_name: str):
+    """A delete racing this request can remove the VM between find_vm and the
+    action; surface that as the same not-found ValueError (→ 404), not a 500."""
+    if ProxmoxClient._is_missing_vm_error(e):
+        raise ValueError(f"VM {vm_name!r} no longer exists in region {cfg.region_name}") from e
+
+
+async def start(cfg, vm_name: str):
+    vm = await find_vm(cfg, vm_name)
+    try:
+        await _proxmox(cfg).start_vm(vm["node"], vm["vmid"])
+    except Exception as e:
+        _reraise_if_vm_vanished(e, cfg, vm_name)
         raise
 
 
-def build_iso(user_data: bytes, meta_data: bytes) -> bytes:
-    iso = pycdlib.PyCdlib()
-    iso.new(vol_ident="cidata", rock_ridge="1.09")
-    iso.add_fp(io.BytesIO(user_data), length=len(user_data), iso_path="/USERDATA;1", rr_name="user-data")
-    iso.add_fp(io.BytesIO(meta_data), length=len(meta_data), iso_path="/METADATA;1", rr_name="meta-data")
-    buf = io.BytesIO()
-    iso.write_fp(buf)
-    iso.close()
-    return buf.getvalue()
-
-
-async def upload_iso(cfg, node: str, vm_name: str, iso_bytes: bytes) -> str:
-    iso_filename = f"{vm_name}-cloudinit.iso"
-    upid = await _post(
-        cfg,
-        f"/nodes/{node}/storage/{cfg.proxmox_storage}/upload",
-        data={"content": "iso"},
-        files={"filename": (iso_filename, io.BytesIO(iso_bytes), "application/octet-stream")}
-    )
-    await poll_task(cfg, upid)
-    return iso_filename
-
-
-async def eject_and_delete_iso(cfg, node: str, vmid: str, iso_filename: str):
+async def stop(cfg, vm_name: str):
+    vm = await find_vm(cfg, vm_name)
     try:
-        await _put(cfg, f"/nodes/{node}/qemu/{vmid}/config", data={"ide2": "none,media=cdrom"})
+        await _proxmox(cfg).stop_vm(vm["node"], vm["vmid"])
     except Exception as e:
-        logger.error(f"Failed to eject ISO from VM {vmid}: {e}")
+        _reraise_if_vm_vanished(e, cfg, vm_name)
+        raise
+
+
+async def edit_tags(cfg, vm_name: str, tags: dict):
+    vm = await find_vm(cfg, vm_name)
     try:
-        iso_volid = urllib.parse.quote(f"{cfg.proxmox_storage}:iso/{iso_filename}", safe="")
-        await _delete(cfg, f"/nodes/{node}/storage/{cfg.proxmox_storage}/content/{iso_volid}")
+        await _proxmox(cfg).update_vm_config(vm["node"], vm["vmid"], description=_encode_description(tags))
     except Exception as e:
-        logger.error(f"Failed to delete ISO {iso_filename}: {e}")
+        _reraise_if_vm_vanished(e, cfg, vm_name)
+        raise
 
 
-async def create_vm(cfg, node: str, vmid: str, vm_name: str, vcpus: int, memory_mb: int, image: str, iso_filename: str, tags: dict):
-    upid = await _post(cfg, f"/nodes/{node}/qemu", data={
-        "vmid": vmid,
-        "name": vm_name,
-        "memory": memory_mb,
-        "cores": vcpus,
-        "cpu": "x86-64-v2-AES",
-        "ostype": "l26",
-        "agent": "1",
-        "virtio0": f"{cfg.proxmox_storage}:0,import-from={cfg.proxmox_storage}:import/{image}.qcow2,iothread=1,format=raw",
-        "ide2": f"{cfg.proxmox_storage}:iso/{iso_filename},media=cdrom",
-        "boot": "order=virtio0",
-        "net0": f"virtio,bridge={cfg.proxmox_bridge},tag={cfg.proxmox_vlan_tag}",
-        "serial0": "socket",
-        "description": _encode_description(tags),
-    })
-    await poll_task(cfg, upid)
-
-
-async def resize_disk(cfg, node: str, vmid: str, storage_mb: int):
-    result = await _put(cfg, f"/nodes/{node}/qemu/{vmid}/resize", data={"disk": "virtio0", "size": f"{storage_mb}M"})
-    if isinstance(result, str) and result.startswith("UPID:"):
-        await poll_task(cfg, result)
-
-
-async def _agent_exec(cfg, node: str, vmid: str, command: list[str]) -> str:
-    async with _client(cfg) as c:
-        r = await c.post(
-            f"{_base(cfg)}/nodes/{node}/qemu/{vmid}/agent/exec",
-            json={"command": command, "input-data": ""},
+async def _prune_image_cache(cfg):
+    """Best-effort: drop cached cde-codespaces image volumes beyond the newest
+    _IMAGE_CACHE_KEEP offered versions (plus any image an in-flight create is
+    importing from). Never raises — a prune failure must not fail the delete
+    that triggered it. If the offered-releases fetch fails, the prune is
+    skipped entirely: never prune against an unknown keep-set."""
+    try:
+        offered = await asyncio.to_thread(
+            github.get_codespace_releases, os.environ["PROVISIONER_ENVIRONMENT"]
         )
-        r.raise_for_status()
-        pid = r.json()["data"]["pid"]
-    for _ in range(60):
-        result = await _get(cfg, f"/nodes/{node}/qemu/{vmid}/agent/exec-status", pid=pid)
-        if result.get("exited"):
-            if result.get("exitcode", 1) != 0:
-                raise RuntimeError(f"Command exited {result.get('exitcode')}: {result.get('err-data', '')!r}")
-            return result.get("out-data", "") + result.get("err-data", "")
-        await asyncio.sleep(3)
-    raise RuntimeError("Command did not exit within 180s")
-
-
-async def wait_for_cloud_init(cfg, node: str, vmid: str, agent_timeout: int = 120, cloudinit_timeout: int = 300):
-    """Poll guest agent until up, then poll cloud-init completion."""
-    loop = asyncio.get_running_loop()
-    agent_end = loop.time() + agent_timeout
-    while loop.time() < agent_end:
-        try:
-            await _get(cfg, f"/nodes/{node}/qemu/{vmid}/agent/info")
-            logger.info(f"VM {vmid}: guest agent up, polling cloud-init status")
-            break
-        except (httpx.HTTPStatusError, httpx.TransportError):
-            await asyncio.sleep(5)
-    else:
-        logger.warning(f"VM {vmid}: guest agent not available after {agent_timeout}s, ejecting ISO anyway")
-        return
-    cloudinit_end = loop.time() + cloudinit_timeout
-    while loop.time() < cloudinit_end:
-        try:
-            await _agent_exec(cfg, node, vmid, ["ls", "/var/lib/cloud/instance/boot-finished"])
-            logger.info(f"VM {vmid}: cloud-init complete")
-            return
-        except (RuntimeError, httpx.HTTPStatusError, httpx.TransportError) as e:
-            logger.debug(f"VM {vmid}: cloud-init not ready: {e}")
-        await asyncio.sleep(5)
-    logger.warning(f"VM {vmid}: cloud-init did not complete within {cloudinit_timeout}s, ejecting ISO anyway")
-
-
-async def start_vm(cfg, node: str, vmid: str):
-    upid = await _post(cfg, f"/nodes/{node}/qemu/{vmid}/status/start")
-    await poll_task(cfg, upid)
-
-
-async def stop_vm(cfg, node: str, vmid: str):
-    upid = await _post(cfg, f"/nodes/{node}/qemu/{vmid}/status/stop")
-    await poll_task(cfg, upid)
-
-
-async def delete_vm(cfg, node: str, vmid: str):
-    try:
-        status_data = await _get(cfg, f"/nodes/{node}/qemu/{vmid}/status/current")
-        if status_data.get("status") == "running":
-            upid = await _post(cfg, f"/nodes/{node}/qemu/{vmid}/status/stop")
-            await poll_task(cfg, upid)
     except Exception as e:
-        logger.error(f"Failed to stop VM {vmid} before delete: {e}")
-    upid = await _delete(cfg, f"/nodes/{node}/qemu/{vmid}", purge=1)
-    await poll_task(cfg, upid)
+        logger.warning(f"Skipping image-cache prune for {cfg.region_name}: could not list offered images: {e}")
+        return
+    try:
+        keep = {f"{_CDE_PREFIX}{tag}" for tag in (offered or [])[:_IMAGE_CACHE_KEEP]}
+        keep |= set(_inflight_images.get(cfg.region_name) or ())
+        deleted = await _proxmox(cfg).prune_import_images(
+            rf"{re.escape(_CDE_PREFIX)}v[^/]*\.qcow2", keep=keep
+        )
+        if deleted:
+            logger.info(f"Pruned {deleted} cached image volume(s) in {cfg.region_name}")
+    except Exception as e:
+        logger.error(f"Image-cache prune failed for {cfg.region_name}: {e}")
 
 
-async def find_vmid_by_name(cfg, node: str, vm_name: str) -> str:
-    vms = await _get(cfg, f"/nodes/{node}/qemu")
-    for vm in (vms or []):
-        if vm.get("name") == vm_name:
-            return str(vm["vmid"])
-    raise ValueError(f"VM {vm_name!r} not found on node {node}")
+async def delete(cfg, vm_name: str):
+    """Delete the VM, then release the Waggle pool. Serialized per (region,
+    vm_name) against concurrent create/delete, and idempotent under retry.
+
+    The pool is intentionally kept — and the request fails — if a VM deletion
+    fails OR a tagged VM had to be skipped as unmanaged: as long as anything
+    tagged with this name may still occupy a hypervisor, Waggle must keep the
+    capacity booked. The orphan ISO sweep and image-cache prune run afterwards
+    as a fire-and-forget background task (see _background_cleanup), so slow
+    cluster-wide sweeps never delay or fail the user's delete."""
+    async with _vm_lock(cfg, vm_name):
+        await _delete_locked(cfg, vm_name)
+    _spawn_background_cleanup(cfg, vm_name)
 
 
-async def edit_vm_tags(cfg, node: str, vmid: str, tags: dict):
-    await _put(cfg, f"/nodes/{node}/qemu/{vmid}/config", data={
-        "description": _encode_description(tags)
-    })
+async def _delete_locked(cfg, vm_name: str):
+    px = _proxmox(cfg)
+    waggle = _waggle()
+    # Resolve the datacenter (and subscript its id) up front: pool cleanup
+    # below is scoped to it (a same-named pool in ANOTHER datacenter must
+    # never be released from here), and a Waggle outage or malformed response
+    # then fails the delete before anything is destroyed instead of leaving a
+    # half-done VM-gone/pool-booked state.
+    datacenter = await waggle.get_datacenter_by_name(cfg.waggle_datacenter_name)
+    datacenter_id = datacenter["id"]
+    vms = await px.list_vms_by_tags([CREATOR_TAG, vm_name])
+    if not vms:
+        logger.warning(f"No VM tagged {vm_name!r} in region {cfg.region_name}; cleaning up Waggle pool anyway")
+    skipped = []
+    for vm in vms:
+        managed = await _is_vm_managed(px, vm)
+        if managed is None:
+            continue  # vanished between listing and check — already deleted
+        if not managed:
+            logger.warning(
+                f"NOT deleting VM {vm['vmid']} on {vm['node']}: tagged [{CREATOR_TAG}, {vm_name}] "
+                f"but missing the managed-by description marker"
+            )
+            skipped.append(vm["vmid"])
+            continue
+        await px.delete_vm(vm["node"], vm["vmid"])
+    if skipped:
+        raise RuntimeError(
+            f"Refusing to release Waggle pool {_pool_name(vm_name)!r}: VM(s) {', '.join(skipped)} "
+            f"carry our tags but not the managed-by description marker and were left in place. "
+            f"Restore or remove them in Proxmox, then retry the delete."
+        )
+    for pool in await waggle.find_pools_by_name(_pool_name(vm_name)):
+        if pool.get("datacenter_id") == datacenter_id:
+            await waggle.delete_pool(pool["id"])
+
+
+def _spawn_background_cleanup(cfg, vm_name: str):
+    task = asyncio.create_task(_background_cleanup(cfg, vm_name))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+async def _background_cleanup(cfg, vm_name: str):
+    """Post-delete housekeeping, entirely best-effort: sweep this VM's orphaned
+    cloud-init ISO (under the per-VM lock, so it can't race a same-name create)
+    and prune the image cache. Failures only log — orphans self-heal on a
+    later delete's sweep."""
+    try:
+        async with _vm_lock(cfg, vm_name):
+            await _proxmox(cfg).delete_isos_matching(
+                rf"{re.escape(_CDE_PREFIX)}{re.escape(vm_name)}-cloudinit\.iso"
+            )
+    except Exception as e:
+        logger.error(f"Orphan ISO sweep failed for {vm_name}: {e}")
+    await _prune_image_cache(cfg)
 
 
 async def list_vms(cfg) -> list:
-    resources = await _get(cfg, "/cluster/resources", type="vm")
-    qemu_vms = [r for r in (resources or []) if r.get("type") == "qemu"]
+    """Return every managed VM in this region in the /v1/list contract shape."""
+    px = _proxmox(cfg)
+    vms = await px.list_vms_by_tags([CREATOR_TAG])
 
-    async def get_vm_details(r):
+    async def get_vm_details(vm):
         try:
-            vm_config = await _get(cfg, f"/nodes/{r['node']}/qemu/{r['vmid']}/config")
-            desc = vm_config.get("description", "")
+            config = await px.get_vm_config(vm["node"], vm["vmid"])
+            desc = config.get("description", "")
             if not _is_managed(desc):
                 return None
             tags = _decode_description(desc)
         except Exception:
             return None
         return {
-            "dom_id": str(r["vmid"]),
-            "name": r.get("name", ""),
-            "region_name": f"{cfg.region_name}-{r['node']}",
-            "state": r.get("status", "unknown"),
+            "dom_id": vm["vmid"],
+            "name": vm["name"],
+            "region_name": cfg.region_name,
+            "state": vm["status"],
             "tags": tags,
         }
 
-    results = await asyncio.gather(*[get_vm_details(r) for r in qemu_vms])
+    results = await asyncio.gather(*[get_vm_details(vm) for vm in vms])
     return [r for r in results if r is not None]
 
 
-async def get_nodes_with_capacity(cfg) -> list:
-    nodes = await _get(cfg, "/nodes")
-    results = []
-    for n in (nodes or []):
-        if n.get("status") != "online":
-            continue
-        node = n["node"]
-        try:
-            storage = await _get(cfg, f"/nodes/{node}/storage/{cfg.proxmox_storage}/status")
-            free_storage_gb = int(storage.get("avail", 0) // (1024 ** 3))
-            total_storage_gb = int(storage.get("total", 0) // (1024 ** 3))
-        except Exception:
-            free_storage_gb = 0
-            total_storage_gb = 0
-        total_vcpus = int(n.get("maxcpu") or 0)
-        total_memory_mb = int(n.get("maxmem") or 0)
-        total_memory_gb = int(total_memory_mb // (1024 ** 3))
-        vms = await _get(cfg, f"/nodes/{node}/qemu") or []
-        alloc_vcpus = sum(int(vm.get("cpus", 0)) for vm in vms)
-        alloc_memory_mb = sum(int(vm.get("maxmem", 0)) for vm in vms)
-        free_vcpus = max(0, total_vcpus - alloc_vcpus)
-        free_memory_gb = max(0, int((total_memory_mb - alloc_memory_mb) // (1024 ** 3)))
-        cpu_pct = int(n.get("cpu", 0) * 100)
-        ram_pct = int(n.get("mem", 0) / total_memory_mb * 100) if total_memory_mb else 0
-
-        def _instance_type_entry(it):
-            d = it.model_dump()
-            if it.vcpus > free_vcpus or it.memory_mb > free_memory_gb * 1024 or it.storage_mb > free_storage_gb * 1024:
-                d["instance_type"] += _OVER_ALLOCATED
-            return d
-
-        results.append({
-            "region_name": f"{cfg.region_name}-{node}",
-            "enabled": cfg.enabled,
-            "available_instance_types": [_instance_type_entry(it) for it in cfg.available_instance_types],
-            "total_vcpus": total_vcpus,
-            "total_memory_gb": total_memory_gb,
-            "total_storage_gb": total_storage_gb,
-            "free_vcpus": free_vcpus,
-            "free_memory_gb": free_memory_gb,
-            "free_storage_gb": free_storage_gb,
-            "cpu_pct": cpu_pct,
-            "ram_pct": ram_pct,
-        })
-    return results
-
-
-def parse_proxmox_region_name(region_name: str, configs: list) -> tuple:
-    """Strip capacity suffix and find the matching ProxmoxConfig + node name."""
-    stable = _CAPACITY_SUFFIX.sub("", region_name)
-    for cfg in configs:
-        if getattr(cfg, "backend_type", "libvirt") != "proxmox":
-            continue
-        prefix = cfg.region_name + "-"
-        if stable.startswith(prefix):
-            node = stable[len(prefix):]
-            if node:
-                return cfg, node
-    raise ValueError(f"No Proxmox config found for region: {region_name}")
+async def get_region(cfg) -> dict:
+    """One region entry per Waggle datacenter. available_instance_types lists
+    only the Waggle slots that can currently be placed (fit within the bookable
+    capacity of at least one schedulable hypervisor) — a slot that is listed is
+    a slot a VM can be created with right now."""
+    waggle = _waggle()
+    datacenter = await waggle.get_datacenter_by_name(cfg.waggle_datacenter_name)
+    slots = await waggle.list_available_slots(datacenter["id"])
+    return {
+        "region_name": cfg.region_name,
+        "enabled": cfg.enabled,
+        "available_instance_types": [
+            {
+                "instance_type": s["name"],
+                "vcpus": s["vcpu"],
+                "memory_mb": s["ram_gb"] * 1024,
+                "storage_mb": s["disk_gb"] * 1024,
+            }
+            for s in slots
+        ],
+    }

--- a/app/util/regions.py
+++ b/app/util/regions.py
@@ -16,7 +16,9 @@ class InstanceType(BaseModel):
 class RegionBase(BaseModel):
     region_name: str
     enabled: bool
-    available_instance_types: List[InstanceType]
+    # Libvirt regions declare instance types in config; Proxmox regions get
+    # theirs from Waggle slots at request time, so the field defaults empty.
+    available_instance_types: List[InstanceType] = []
     total_vcpus: Optional[int] = None
     total_memory_gb: Optional[int] = None
     total_storage_gb: Optional[int] = None
@@ -29,6 +31,9 @@ class RegionBase(BaseModel):
 
 class SSHConfig(RegionBase):
     backend_type: str = "libvirt"
+    # Required for libvirt (re-declared without the RegionBase default): a
+    # typo'd key in config should fail startup, not silently offer no sizes.
+    available_instance_types: List[InstanceType]
     user: str
     host: str
     port: int
@@ -41,15 +46,29 @@ class SSHConfig(RegionBase):
 
 
 class ProxmoxConfig(RegionBase):
+    """One Waggle datacenter backed by one Proxmox cluster.
+
+    Waggle decides which hypervisor each VM lands on; the Proxmox credentials
+    here are what the provisioner uses to actually create the VMs (Waggle
+    stores its own Proxmox token write-only and never returns it).
+    """
     backend_type: str = "proxmox"
+    # Waggle datacenter this region maps to; defaults to region_name.
+    waggle_datacenter_name: Optional[str] = None
     proxmox_host: str
     proxmox_port: int = 8006
     proxmox_token_id: str = Field(exclude=True)
     proxmox_token_secret: str = Field(exclude=True)
     proxmox_storage: str
     proxmox_bridge: str
-    proxmox_vlan_tag: int
+    proxmox_vlan_tag: Optional[int] = None
     proxmox_verify_ssl: bool = True
+
+    @model_validator(mode='after')
+    def default_datacenter_name(self) -> 'ProxmoxConfig':
+        if not self.waggle_datacenter_name:
+            self.waggle_datacenter_name = self.region_name
+        return self
 
 
 def load_configs_from_env(server_configs) -> List[Union[SSHConfig, ProxmoxConfig]]:


### PR DESCRIPTION
## Summary

Shifts the proxmox backend from direct per-node provisioning to **Waggle-backed placement**: one provisioner region == one Waggle datacenter == one proxmox cluster. Waggle picks the hypervisor (anti-affinity, all-or-nothing); the provisioner provisions there via the `glueops-helpers` `ProxmoxClient`/`WaggleClient` (v0.8.0) and backfills the vmid onto the placement. **Libvirt regions are untouched.**

### Model
- **Create**: per-`(region, vm_name)` lock → datacenter/slot lookup → waggle pool `cde-codespaces-{vm_name}` (`desired_count=1`) → provision on the placement's hypervisor → best-effort vmid backfill → resize to slot disk → start → cloud-init wait. Compensates (VM + pool) only after provisioning starts; pool kept if VM deletion fails (no overbooking)
- **Delete**: datacenter resolved before any destruction (waggle outage fails cleanly up front); VM removal requires native tags **and** the `managed-by` description marker (tags are hand-editable — a tagged-but-unmarked VM fails the delete and keeps the pool); pool release scoped to the region's datacenter; idempotent under retry. ISO sweep + image-cache prune run as a fire-and-forget background task
- **`/v1/regions`**: one entry per datacenter; `available_instance_types` = waggle slots **pre-filtered to what's placeable right now** (no capacity fields, no `(Over Allocated)`, no live proxmox scans); a failing region is skipped, never 500s the endpoint
- **Ownership**: VMs tagged `[glueops-provisioner, cde, codespaces, {vm_name}]`; every storage artifact (cached images, cloud-init ISOs) and waggle pool carries the `cde-codespaces-` prefix so sweeps only ever match our resources
- **Image cache**: images cached per node as `cde-codespaces-{tag}.qcow2`; pruned on delete keeping the newest `PROXMOX_IMAGE_CACHE_KEEP` (default 5) offered releases ∪ in-flight images; evicted versions re-download on demand
- **Errors**: `UnknownTargetError`→422, `PlacementError`→409 (at capacity), VM-not-found→404 — all with actionable `detail`; `vm_name`/`image` pattern-validated at the boundary; `user_data`/tag values no longer logged
- Deliberately **no duplicate-name guard** on create (callers generate unique names and never retry) — documented as a non-goal

### Config (breaking)
Proxmox region entries now carry `waggle_datacenter_name` (defaults to `region_name`) + proxmox credentials only; `WAGGLE_API_URL`/`WAGGLE_API_KEY` env vars required when proxmox regions exist. README includes a step-by-step **datacenter onboarding runbook** incl. the load-bearing invariant that waggle hypervisor names must equal proxmox node names (guaranteed by discovery). Proxmox VE 8.4+ required.

## Dependencies / merge order
1. GlueOps/python-glueops-helpers-library#26 must merge **and be tagged v0.8.0** first — the Pipfile pins `archive/refs/tags/v0.8.0.zip`
2. Pairs with the slackbot PR (UI adaptation); this API keeps the existing wire contract shapes

## Testing
No test infra in-repo; verified via stub-based suites in Docker (python:3.11-slim): 40+ checks covering placement/compensation end-states at every failure stage, lock serialization, idempotent retries, datacenter scoping, prune keep-sets, schema patterns (incl. exhaustive verification that every `unique-names-generator` output passes `VM_NAME_PATTERN`), and `/v1/regions` per-region degradation with an unreachable waggle. Six independent review passes (correctness, concurrency, security, DevX, PO, UX) + a final docs-vs-code audit. Live cluster testing still pending (nonprod create→delete recommended before deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)