### PR TITLE
feat!: per-region waggle credentials

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -51,9 +51,8 @@ Do not use `python3` directly, `.venv`, or `devbox shell --`. The `devbox run --
 import asyncio, os, sys
 sys.path.insert(0, "/workspaces/glueops/provisioner")
 
-# The module reads Waggle + image-server settings from env
-os.environ["WAGGLE_API_URL"] = "<WAGGLE_URL>"
-os.environ["WAGGLE_API_KEY"] = "wgl_..."
+# The module reads the image-server setting from env; Waggle credentials
+# are per region config (multiple Waggle orgs/servers supported).
 os.environ["PROXMOX_DOWNLOAD_SERVER_URL"] = "<DOWNLOAD_BASE_URL>"
 
 from app.util import proxmox, regions
@@ -61,6 +60,8 @@ from app.util import proxmox, regions
 cfg = regions.ProxmoxConfig(
     region_name="<REGION_NAME>",                      # == Waggle datacenter name (or set waggle_datacenter_name)
     enabled=True,
+    waggle_api_url="<WAGGLE_URL>",
+    waggle_api_key="wgl_...",
     proxmox_host="<PROXMOX_HOST_OR_IP>",
     proxmox_port=8006,
     proxmox_token_id="<USER>@<REALM>!<TOKENNAME>",   # e.g. root@pam!mytoken
@@ -129,7 +130,7 @@ High-level orchestration; all Proxmox/Waggle HTTP calls live in the glueops-help
 
 Helpers clients available in test scripts:
 - `proxmox._proxmox(cfg)` — cached `glueops.proxmox.ProxmoxClient` for the region
-- `proxmox._waggle()` — cached `glueops.waggle.WaggleClient` (env-configured)
+- `proxmox._waggle(cfg)` — cached `glueops.waggle.WaggleClient` for the region's org (entries sharing `waggle_api_url`+`waggle_api_key` share a client)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,7 @@ There are no automated tests or linting tools configured in this project.
 | `API_TOKEN` | Bearer token for all API endpoints |
 | `PROVISIONER_ENVIRONMENT` | `prod` or `nonprod` (filters GitHub image releases) |
 | `DOWNLOAD_SERVER_URL` | Base URL for VM disk images (libvirt regions) |
-| `WAGGLE_API_URL` | Base URL of the Waggle server (org-level, shared by all Proxmox regions); required only if any Proxmox region is configured |
-| `WAGGLE_API_KEY` | Waggle org API key (`wgl_...`); required only if any Proxmox region is configured |
-| `PROXMOX_DOWNLOAD_SERVER_URL` | Base URL for VM disk images (Proxmox regions); required only if any Proxmox region is configured |
+| `PROXMOX_DOWNLOAD_SERVER_URL` | Base URL for VM disk images (Proxmox regions); required only if any Proxmox region is configured. Waggle credentials are NOT env vars — they live per region entry (`waggle_api_url`/`waggle_api_key`), so regions can span multiple Waggle orgs/servers |
 | `BAREMETAL_SERVER_CONFIGS` | JSON array of region configs — libvirt (`SSHConfig`) or Proxmox (`ProxmoxConfig`) entries; detected by `backend_type` field (defaults to `"libvirt"`) |
 | `GUACAMOLE_SERVER_URL` / `_USERNAME` / `_PASSWORD` | Guacamole credentials |
 | `BASTION_SERVER_IP` / `_PORT` / `_USER` / `_KEY` | Bastion host for Guacamole connections |
@@ -85,6 +83,8 @@ One entry per Waggle datacenter. The datacenter, its hypervisors, and the slots 
   "backend_type": "proxmox",
   "region_name": "proxmox-cluster-1",
   "enabled": true,
+  "waggle_api_url": "https://waggle.example.com",
+  "waggle_api_key": "wgl_...",
   "waggle_datacenter_name": "proxmox-cluster-1",
   "proxmox_host": "1.2.3.4",
   "proxmox_port": 8006,

--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ BAREMETAL_SERVER_CONFIGS=         # JSON array of region configs (see below)
 ### Required if any Proxmox region is configured
 
 ```bash
-WAGGLE_API_URL=                   # base URL of the Waggle server (org-level; shared by all Proxmox regions)
-WAGGLE_API_KEY=                   # Waggle org API key (wgl_...)
 PROXMOX_DOWNLOAD_SERVER_URL=      # base URL for VM disk images (Proxmox regions)
+```
+
+Waggle credentials are **per region entry** (`waggle_api_url` / `waggle_api_key` in `BAREMETAL_SERVER_CONFIGS`), not env vars — different regions can belong to different Waggle orgs or servers.
+
+```bash
 ```
 
 ### Optional
@@ -90,6 +93,8 @@ A JSON array of region config objects. Each entry is either a libvirt (`SSHConfi
   "backend_type": "proxmox",
   "region_name": "proxmox-cluster-1",
   "enabled": true,
+  "waggle_api_url": "https://waggle.example.com",
+  "waggle_api_key": "wgl_...",
   "waggle_datacenter_name": "proxmox-cluster-1",
   "proxmox_host": "1.2.3.4",
   "proxmox_port": 8006,
@@ -167,7 +172,7 @@ Do these **in order** — the region only works once all of them exist:
 3. **Set operator capacity policy per hypervisor**: `reserved` headroom and the `schedulable` flag. Both are preserved across re-discovery; set `schedulable: false` to drain a node for maintenance.
 4. **Ensure slots exist** (org-level, shared by all datacenters). Slot names are exactly the instance types users see in the Slack dropdown; `vcpu`/`ram_gb`/`disk_gb` are what gets provisioned.
 5. **Create a PVE API token for the provisioner** — separate from Waggle's discovery token — with permission to create/delete/configure VMs and upload to the storage pool.
-6. **Add the region entry** to `BAREMETAL_SERVER_CONFIGS` (see format above), set `WAGGLE_API_URL`, `WAGGLE_API_KEY`, and `PROXMOX_DOWNLOAD_SERVER_URL`, and deploy.
+6. **Add the region entry** to `BAREMETAL_SERVER_CONFIGS` (see format above) with the org's `waggle_api_url`/`waggle_api_key` and the datacenter's Proxmox credentials, make sure `PROXMOX_DOWNLOAD_SERVER_URL` is set, and deploy.
 7. **Verify**: `GET /v1/regions` must list the region with the expected slots. A region that silently disappears from the response means its Waggle lookup failed — check the provisioner logs for `Skipping region <name>`.
 
 > ⚠️ **Load-bearing invariant: Waggle hypervisor names must equal Proxmox node names.** The provisioner uses a placement's `hypervisor_name` verbatim as the node in Proxmox API paths. Discovery guarantees this automatically — never hand-create hypervisor entries in Waggle with different names, or every create in that datacenter will fail.

--- a/app/main.py
+++ b/app/main.py
@@ -31,11 +31,11 @@ except KeyError as e:
     logger.critical(f"Required environment variable {e} is not set")
     raise SystemExit(1)
 
-if HAS_PROXMOX:
-    _missing = [k for k in ('WAGGLE_API_URL', 'WAGGLE_API_KEY', 'PROXMOX_DOWNLOAD_SERVER_URL') if not os.environ.get(k)]
-    if _missing:
-        logger.critical(f"Required when Proxmox regions are configured but not set: {', '.join(_missing)}")
-        raise SystemExit(1)
+# Waggle credentials live per-region in BAREMETAL_SERVER_CONFIGS (validated by
+# the ProxmoxConfig model), so the only proxmox-wide env var is the image server.
+if HAS_PROXMOX and not os.environ.get('PROXMOX_DOWNLOAD_SERVER_URL'):
+    logger.critical("PROXMOX_DOWNLOAD_SERVER_URL is required when Proxmox regions are configured")
+    raise SystemExit(1)
 
 api_key_header = APIKeyHeader(name="Authorization")
 

--- a/app/util/proxmox.py
+++ b/app/util/proxmox.py
@@ -43,7 +43,7 @@ _CDE_PREFIX = "cde-codespaces-"
 # delete and simply re-download on demand if requested again.
 _IMAGE_CACHE_KEEP = int(os.getenv("PROXMOX_IMAGE_CACHE_KEEP", "5"))
 
-_waggle_client = None
+_waggle_clients = {}  # (waggle_api_url, waggle_api_key) -> WaggleClient, shared across same-org regions
 _proxmox_clients = {}  # region_name -> ProxmoxClient
 # region_name -> Counter of cached-image names used by in-flight creates;
 # the prune keep-set includes these so a concurrent create's import source
@@ -113,11 +113,13 @@ def _pool_name(vm_name: str) -> str:
     return f"{_CDE_PREFIX}{vm_name}"
 
 
-def _waggle() -> WaggleClient:
-    global _waggle_client
-    if _waggle_client is None:
-        _waggle_client = WaggleClient(os.environ["WAGGLE_API_URL"], os.environ["WAGGLE_API_KEY"])
-    return _waggle_client
+def _waggle(cfg) -> WaggleClient:
+    key = (cfg.waggle_api_url, cfg.waggle_api_key)
+    client = _waggle_clients.get(key)
+    if client is None:
+        client = WaggleClient(cfg.waggle_api_url, cfg.waggle_api_key)
+        _waggle_clients[key] = client
+    return client
 
 
 def _proxmox(cfg) -> ProxmoxClient:
@@ -194,7 +196,7 @@ async def create(cfg, vm_name: str, tags: dict, user_data: str, image: str, inst
 
 
 async def _create_locked(cfg, vm_name: str, tags: dict, user_data: str, image: str, instance_type: str):
-    waggle = _waggle()
+    waggle = _waggle(cfg)
     px = _proxmox(cfg)
     try:
         datacenter = await waggle.get_datacenter_by_name(cfg.waggle_datacenter_name)
@@ -381,7 +383,7 @@ async def delete(cfg, vm_name: str):
 
 async def _delete_locked(cfg, vm_name: str):
     px = _proxmox(cfg)
-    waggle = _waggle()
+    waggle = _waggle(cfg)
     # Resolve the datacenter (and subscript its id) up front: pool cleanup
     # below is scoped to it (a same-named pool in ANOTHER datacenter must
     # never be released from here), and a Waggle outage or malformed response
@@ -468,7 +470,7 @@ async def get_region(cfg) -> dict:
     only the Waggle slots that can currently be placed (fit within the bookable
     capacity of at least one schedulable hypervisor) — a slot that is listed is
     a slot a VM can be created with right now."""
-    waggle = _waggle()
+    waggle = _waggle(cfg)
     datacenter = await waggle.get_datacenter_by_name(cfg.waggle_datacenter_name)
     slots = await waggle.list_available_slots(datacenter["id"])
     return {

--- a/app/util/regions.py
+++ b/app/util/regions.py
@@ -53,6 +53,11 @@ class ProxmoxConfig(RegionBase):
     stores its own Proxmox token write-only and never returns it).
     """
     backend_type: str = "proxmox"
+    # Waggle org this datacenter belongs to. Each region entry carries its own
+    # credentials, so different regions can live in different Waggle orgs or
+    # servers; entries sharing the same url+key share one client.
+    waggle_api_url: str
+    waggle_api_key: str = Field(exclude=True)
     # Waggle datacenter this region maps to; defaults to region_name.
     waggle_datacenter_name: Optional[str] = None
     proxmox_host: str


### PR DESCRIPTION
## Summary

Fixes the single-org limitation: waggle credentials move from global env vars into each proxmox region entry, so different regions can belong to **different waggle orgs or servers**.

- `ProxmoxConfig` gains required `waggle_api_url` + `waggle_api_key` (key is `Field(exclude=True)` — verified it never serializes into `/v1/regions`)
- `WaggleClient`s are cached per `(url, key)`, so same-org entries share one client
- `WAGGLE_API_URL`/`WAGGLE_API_KEY` env vars removed (startup check now only requires `PROXMOX_DOWNLOAD_SERVER_URL`); missing per-entry credentials fail startup via pydantic validation
- Docs updated: README env section + config example + onboarding runbook step 6, CLAUDE.md env table, .ai/AGENTS.md test-script example

Dynamic datacenter discovery was considered and **deliberately rejected** (proxmox credentials are per-datacenter, so explicit entries stay).

## Breaking change

Proxmox region config only — add `waggle_api_url`/`waggle_api_key` to each entry, drop the env vars. Libvirt untouched. Proxmox is not yet deployed anywhere.

## Testing

Full stub-based regression suites re-run in Docker (39 checks, all passing), including: per-region client wiring across both create/delete paths, `/v1/regions` degradation with a per-region unreachable waggle URL, required-field validation, and api-key serialization exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)