### PR TITLE
feat: add tunnel_endpoint to region configs and /v1/regions

### DIFF
--- a/app/util/proxmox.py
+++ b/app/util/proxmox.py
@@ -476,6 +476,7 @@ async def get_region(cfg) -> dict:
     return {
         "region_name": cfg.region_name,
         "enabled": cfg.enabled,
+        "tunnel_endpoint": cfg.tunnel_endpoint,
         "available_instance_types": [
             {
                 "instance_type": s["name"],

--- a/app/util/regions.py
+++ b/app/util/regions.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union
-from pydantic import BaseModel, Field, model_validator
-import os, glueops.setup_logging, json
+from pydantic import BaseModel, Field, field_validator, model_validator
+import os, re, glueops.setup_logging, json
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 logger = glueops.setup_logging.configure(level=LOG_LEVEL)
@@ -16,6 +16,30 @@ class InstanceType(BaseModel):
 class RegionBase(BaseModel):
     region_name: str
     enabled: bool
+    # sish host codespace VMs in this region tunnel to (e.g.
+    # "nyc1.tunnels.cde.glueopshosted.com"). None -> the legacy central
+    # tunnel; consumers (the slackbot) own that default.
+    tunnel_endpoint: Optional[str] = None
+
+    @field_validator("tunnel_endpoint")
+    @classmethod
+    def validate_tunnel_endpoint(cls, v: Optional[str]) -> Optional[str]:
+        # Bare hostname only — no scheme, port, path, or userinfo. A malformed
+        # value must fail startup rather than propagate: downstream it becomes
+        # a permanent VM tag and access URL while cloud-init independently
+        # drops non-hostname values, leaving the VM tunneled to the legacy
+        # endpoint behind a dead regional URL.
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            return None
+        # ASCII keeps IGNORECASE from Unicode case-folding (e.g. the Kelvin
+        # sign matching "k"), which would accept values the JS-side pattern
+        # (ASCII-only /i) rejects.
+        if not re.fullmatch(r"[a-z0-9][a-z0-9.-]*", v, re.IGNORECASE | re.ASCII):
+            raise ValueError(f"invalid tunnel_endpoint {v!r}: must be a bare hostname")
+        return v
     # Libvirt regions declare instance types in config; Proxmox regions get
     # theirs from Waggle slots at request time, so the field defaults empty.
     available_instance_types: List[InstanceType] = []

--- a/app/util/regions.py
+++ b/app/util/regions.py
@@ -31,13 +31,17 @@ class RegionBase(BaseModel):
         # endpoint behind a dead regional URL.
         if v is None:
             return v
-        v = v.strip()
+        # DNS is case-insensitive and a trailing dot is equivalent, so
+        # normalize rather than just validate: downstream, the legacy-vs-
+        # regional naming split is an EXACT string comparison against
+        # "tunnels.glueopshosted.com" (slackbot cdeAccessUrl and the VM's
+        # developer-setup.sh), and a case/dot variant of the legacy endpoint
+        # would be misclassified as regional — dead URLs for the VM's life.
+        v = v.strip().lower().removesuffix(".")
         if not v:
             return None
-        # ASCII keeps IGNORECASE from Unicode case-folding (e.g. the Kelvin
-        # sign matching "k"), which would accept values the JS-side pattern
-        # (ASCII-only /i) rejects.
-        if not re.fullmatch(r"[a-z0-9][a-z0-9.-]*", v, re.IGNORECASE | re.ASCII):
+        label = r"[a-z0-9]([a-z0-9-]*[a-z0-9])?"
+        if not re.fullmatch(rf"{label}(\.{label})*", v):
             raise ValueError(f"invalid tunnel_endpoint {v!r}: must be a bare hostname")
         return v
     # Libvirt regions declare instance types in config; Proxmox regions get


### PR DESCRIPTION
## What

Adds an optional `tunnel_endpoint` field to region configs, exposed via `/v1/regions` for both libvirt and Proxmox/Waggle backends. It declares which sish host codespace VMs in that region should tunnel to (e.g. `nyc1.tunnels.cde.glueopshosted.com`); the slackbot resolves it at VM create time.

- `RegionBase.tunnel_endpoint: Optional[str] = None` — omitted/`null` means the legacy central tunnel (`tunnels.glueopshosted.com`); the default is owned by consumers, not this API.
- A `field_validator` enforces a **bare hostname** (no scheme, port, path, or userinfo) and fails at startup on a malformed value, following this repo's fail-fast precedent. This matters because downstream the value becomes a permanent VM tag and access URL while cloud-init independently drops non-hostname values — a malformed value slipping through would leave VMs tunneled to the central endpoint behind dead regional URLs.
- Whitespace is trimmed; an empty/whitespace-only value normalizes to `None`.

Part of the regional tunnel endpoints rollout. Companion PRs: GlueOps/codespaces (`dev()` reads `/etc/glueops/tunnel_endpoint`) and GlueOps/slackbot-developer-workspaces (resolution, tagging, URLs).

## Config example

```jsonc
// BAREMETAL_SERVER_CONFIGS entry
{
  "region_name": "nyc1",
  "backend_type": "proxmox",
  "tunnel_endpoint": "nyc1.tunnels.cde.glueopshosted.com",
  ...
}
```

## Backward compatibility

Fully backward compatible: existing configs without the key parse unchanged, `/v1/regions` simply gains a `tunnel_endpoint: null` field, and no create/list/edit behavior changes.

## How to upgrade

1. Deploy this release at any time — it is inert until a region sets `tunnel_endpoint`.
2. Do **not** set `tunnel_endpoint` on a region until the rest of the runbook (slackbot PR) is done for that region: regional sish instance + DNS + wildcard cert live, new codespaces image released, and the slackbot deployed with `REGIONAL_TUNNEL_MIN_IMAGE_TAG` set.
3. Then set `tunnel_endpoint` per region, one region at a time, and restart the provisioner (a typo'd value fails startup by design — fix the value and restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
