### PR TITLE
feat!: require tunnel_endpoint on every region (legacy tunnel removal)

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -59,7 +59,7 @@ from app.util import proxmox, regions
 
 cfg = regions.ProxmoxConfig(
     region_name="<REGION_NAME>",                      # == Waggle datacenter name (or set waggle_datacenter_name)
-    tunnel_endpoint="<REGION_NAME>.tunnels.cde.glueopshosted.com",  # required on every region
+    tunnel_endpoint="usfoobar1.tunnels.cde.glueopshosted.com",  # required; bare hostname, angle-bracket placeholders are rejected
     enabled=True,
     waggle_api_url="<WAGGLE_URL>",
     waggle_api_key="wgl_...",

--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -59,6 +59,7 @@ from app.util import proxmox, regions
 
 cfg = regions.ProxmoxConfig(
     region_name="<REGION_NAME>",                      # == Waggle datacenter name (or set waggle_datacenter_name)
+    tunnel_endpoint="<REGION_NAME>.tunnels.cde.glueopshosted.com",  # required on every region
     enabled=True,
     waggle_api_url="<WAGGLE_URL>",
     waggle_api_key="wgl_...",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ One entry per Waggle datacenter. The datacenter, its hypervisors, and the slots 
 {
   "backend_type": "proxmox",
   "region_name": "proxmox-cluster-1",
+  "tunnel_endpoint": "proxmox-cluster-1.tunnels.cde.glueopshosted.com",
   "enabled": true,
   "waggle_api_url": "https://waggle.example.com",
   "waggle_api_key": "wgl_...",
@@ -98,6 +99,8 @@ One entry per Waggle datacenter. The datacenter, its hypervisors, and the slots 
 ```
 
 `waggle_datacenter_name` defaults to `region_name`; `proxmox_vlan_tag` is optional (omit or `null` for no VLAN tag).
+
+`tunnel_endpoint` is **required on every region** (both backends): the sish host codespace VMs in that region tunnel to, as a bare hostname (no scheme/port/path). It is normalized to lowercase without a trailing dot, and a missing or malformed value fails startup — there is no central tunnel to fall back to.
 
 ## CI/CD
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ A JSON array of region config objects. Each entry is either a libvirt (`SSHConfi
 {
   "backend_type": "libvirt",
   "region_name": "us-east-1",
+  "tunnel_endpoint": "us-east-1.tunnels.cde.glueopshosted.com",
   "enabled": true,
   "host": "10.0.0.1",
   "port": 2222,
@@ -92,6 +93,7 @@ A JSON array of region config objects. Each entry is either a libvirt (`SSHConfi
 {
   "backend_type": "proxmox",
   "region_name": "proxmox-cluster-1",
+  "tunnel_endpoint": "proxmox-cluster-1.tunnels.cde.glueopshosted.com",
   "enabled": true,
   "waggle_api_url": "https://waggle.example.com",
   "waggle_api_key": "wgl_...",

--- a/README.md
+++ b/README.md
@@ -174,7 +174,13 @@ Do these **in order** — the region only works once all of them exist:
 3. **Set operator capacity policy per hypervisor**: `reserved` headroom and the `schedulable` flag. Both are preserved across re-discovery; set `schedulable: false` to drain a node for maintenance.
 4. **Ensure slots exist** (org-level, shared by all datacenters). Slot names are exactly the instance types users see in the Slack dropdown; `vcpu`/`ram_gb`/`disk_gb` are what gets provisioned.
 5. **Create a PVE API token for the provisioner** — separate from Waggle's discovery token — with permission to create/delete/configure VMs and upload to the storage pool.
-6. **Stand up the region's tunnel endpoint**: a sish server serving `<region>.tunnels.cde.glueopshosted.com`, its DNS records (bare A, `origin.` A, wildcard CNAME) and its wildcard certificate. CDE VMs in this region cannot come up without it.
+6. **Stand up the region's tunnel endpoint** — all four artifacts, in order, or cert issuance stalls:
+   1. add `<region>` and `*.<region>` to `module.acme_dns01_user_cde.cert_domains` in **aws-dns-production** so the box's ACME user may write that region's `_acme-challenge` records;
+   2. in **aws-cloud-development-environment-assets-production**, add the region with `create_distribution = false`, apply, and copy the emitted `acm_validation_record_entry` into aws-dns-production along with the region's A records (`<region>.tunnels.cde`, `origin.<region>.tunnels.cde`);
+   3. flip `create_distribution = true`, apply, and copy the emitted `wildcard_cname_entry` (`*.<region>.tunnels.cde`) into aws-dns-production;
+   4. deploy the sish stack (**GlueOps/cde-sish-tunnels**) on the box with `DOMAIN=<region>.tunnels.cde.glueopshosted.com` and the ACME credentials, then smoke-test a tunnel.
+
+   CDE VMs in this region cannot come up without it.
 7. **Add the region entry** to `BAREMETAL_SERVER_CONFIGS` (see format above) with the org's `waggle_api_url`/`waggle_api_key`, the datacenter's Proxmox credentials, and the **required** `tunnel_endpoint` from step 6 — a bare hostname; the provisioner refuses to start if any region omits it or if it is malformed. Make sure `PROXMOX_DOWNLOAD_SERVER_URL` is set, and deploy.
 8. **Verify**: `GET /v1/regions` must list the region with the expected slots. A region that silently disappears from the response means its Waggle lookup failed — check the provisioner logs for `Skipping region <name>`.
 

--- a/README.md
+++ b/README.md
@@ -174,8 +174,9 @@ Do these **in order** — the region only works once all of them exist:
 3. **Set operator capacity policy per hypervisor**: `reserved` headroom and the `schedulable` flag. Both are preserved across re-discovery; set `schedulable: false` to drain a node for maintenance.
 4. **Ensure slots exist** (org-level, shared by all datacenters). Slot names are exactly the instance types users see in the Slack dropdown; `vcpu`/`ram_gb`/`disk_gb` are what gets provisioned.
 5. **Create a PVE API token for the provisioner** — separate from Waggle's discovery token — with permission to create/delete/configure VMs and upload to the storage pool.
-6. **Add the region entry** to `BAREMETAL_SERVER_CONFIGS` (see format above) with the org's `waggle_api_url`/`waggle_api_key` and the datacenter's Proxmox credentials, make sure `PROXMOX_DOWNLOAD_SERVER_URL` is set, and deploy.
-7. **Verify**: `GET /v1/regions` must list the region with the expected slots. A region that silently disappears from the response means its Waggle lookup failed — check the provisioner logs for `Skipping region <name>`.
+6. **Stand up the region's tunnel endpoint**: a sish server serving `<region>.tunnels.cde.glueopshosted.com`, its DNS records (bare A, `origin.` A, wildcard CNAME) and its wildcard certificate. CDE VMs in this region cannot come up without it.
+7. **Add the region entry** to `BAREMETAL_SERVER_CONFIGS` (see format above) with the org's `waggle_api_url`/`waggle_api_key`, the datacenter's Proxmox credentials, and the **required** `tunnel_endpoint` from step 6 — a bare hostname; the provisioner refuses to start if any region omits it or if it is malformed. Make sure `PROXMOX_DOWNLOAD_SERVER_URL` is set, and deploy.
+8. **Verify**: `GET /v1/regions` must list the region with the expected slots. A region that silently disappears from the response means its Waggle lookup failed — check the provisioner logs for `Skipping region <name>`.
 
 > ⚠️ **Load-bearing invariant: Waggle hypervisor names must equal Proxmox node names.** The provisioner uses a placement's `hypervisor_name` verbatim as the node in Proxmox API paths. Discovery guarantees this automatically — never hand-create hypervisor entries in Waggle with different names, or every create in that datacenter will fail.
 

--- a/app/util/regions.py
+++ b/app/util/regions.py
@@ -17,29 +17,24 @@ class RegionBase(BaseModel):
     region_name: str
     enabled: bool
     # sish host codespace VMs in this region tunnel to (e.g.
-    # "nyc1.tunnels.cde.glueopshosted.com"). None -> the legacy central
-    # tunnel; consumers (the slackbot) own that default.
-    tunnel_endpoint: Optional[str] = None
+    # "nyc1.tunnels.cde.glueopshosted.com"). Required: there is no central
+    # tunnel to fall back to, so a region without one cannot serve CDEs and
+    # should fail at config load rather than at VM-create time.
+    tunnel_endpoint: str
 
     @field_validator("tunnel_endpoint")
     @classmethod
-    def validate_tunnel_endpoint(cls, v: Optional[str]) -> Optional[str]:
+    def validate_tunnel_endpoint(cls, v: str) -> str:
         # Bare hostname only — no scheme, port, path, or userinfo. A malformed
         # value must fail startup rather than propagate: downstream it becomes
-        # a permanent VM tag and access URL while cloud-init independently
-        # drops non-hostname values, leaving the VM tunneled to the legacy
-        # endpoint behind a dead regional URL.
-        if v is None:
-            return v
+        # a permanent VM tag, the access URL, and the endpoint the VM's
+        # autossh dials, so a bad value means dead URLs for the VM's life.
         # DNS is case-insensitive and a trailing dot is equivalent, so
-        # normalize rather than just validate: downstream, the legacy-vs-
-        # regional naming split is an EXACT string comparison against
-        # "tunnels.glueopshosted.com" (slackbot cdeAccessUrl and the VM's
-        # developer-setup.sh), and a case/dot variant of the legacy endpoint
-        # would be misclassified as regional — dead URLs for the VM's life.
+        # normalize rather than merely validate — the value is compared and
+        # concatenated as an exact string by every consumer.
         v = v.strip().lower().removesuffix(".")
         if not v:
-            return None
+            raise ValueError("tunnel_endpoint must not be empty")
         label = r"[a-z0-9]([a-z0-9-]*[a-z0-9])?"
         if not re.fullmatch(rf"{label}(\.{label})*", v):
             raise ValueError(f"invalid tunnel_endpoint {v!r}: must be a bare hostname")

--- a/app/util/regions.py
+++ b/app/util/regions.py
@@ -38,6 +38,11 @@ class RegionBase(BaseModel):
         label = r"[a-z0-9]([a-z0-9-]*[a-z0-9])?"
         if not re.fullmatch(rf"{label}(\.{label})*", v):
             raise ValueError(f"invalid tunnel_endpoint {v!r}: must be a bare hostname")
+        if v == "tunnels.glueopshosted.com":
+            raise ValueError(
+                "tunnel_endpoint is the retired central tunnel; use this region's "
+                "<region>.tunnels.cde.glueopshosted.com endpoint"
+            )
         return v
     # Libvirt regions declare instance types in config; Proxmox regions get
     # theirs from Waggle slots at request time, so the field defaults empty.

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,10 +1,6 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "last_modified": "2026-06-28T17:12:19Z",
-      "resolved": "github:NixOS/nixpkgs/534ee3d8beb1737b5342995f8837e2b2705ce0d8?lastModified=1782666739&narHash=sha256-2CYuaRDT7hcYnGW%2B3TTTy%2BfNnY4jQ6%2FmGk6ew035XP4%3D"
-    },
     "libvirt@12.1.0": {
       "last_modified": "2026-04-01T09:13:21Z",
       "resolved": "github:NixOS/nixpkgs/8d029aa64915e54b7846873d9583af4c9fd21ea4#libvirt",


### PR DESCRIPTION
**DRAFT — do not merge until the preconditions below hold.** Part of retiring the legacy central tunnel.

Makes `tunnel_endpoint` a required field on `RegionBase`: a region without one can no longer serve CDEs, so it fails at config load rather than at VM-create time. Empty/whitespace values are rejected too (previously normalized to `None`).

### Precondition
- [ ] **Every** entry in `BAREMETAL_SERVER_CONFIGS` declares a `tunnel_endpoint` — including regions you don't think are used for CDEs. Verify: `GET /v1/regions` returns no entry with `"tunnel_endpoint": null`. The provisioner will **refuse to start** otherwise, so check before deploying.

Companion PRs: GlueOps/slackbot-developer-workspaces (drops the fallback + image gate), GlueOps/codespaces (drops the VM-side fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErBUiAYTosnpbF9hvUj3Dn